### PR TITLE
feat(search): add Heypster provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ go install github.com/steipete/gifgrep/cmd/gifgrep@latest
 - TUI browser: inline preview, quick download, reveal last download.
 - Stills: `still` extracts one frame; `sheet` creates a PNG grid (`--frames`, `--cols`, `--padding`).
 - Color + logging: `--color/--no-color`, `--quiet`, `--verbose`.
-- Providers: `auto` (prefers Giphy when keyed), `tenor`, `giphy`.
+- Providers: `auto` (prefers Giphy when keyed), `tenor`, `giphy`, `heypster`.
 
 ## Quickstart
 
@@ -60,9 +60,10 @@ gifgrep sheet ./clip.gif --frames 9 --cols 3 -o sheet.png
 
 Select via `--source` (search + TUI):
 
-- `auto` (default): picks Giphy when `GIPHY_API_KEY` is set, else Tenor.
+- `auto` (default): picks Giphy when `GIPHY_API_KEY` is set, else Heypster when `HEYPSTER_API_KEY` is set, else Tenor.
 - `tenor`: uses public demo key if `TENOR_API_KEY` is unset.
 - `giphy`: requires `GIPHY_API_KEY`.
+- `heypster`: requires `HEYPSTER_API_KEY`.
 
 ## CLI
 
@@ -105,6 +106,7 @@ iTerm2 uses a different protocol (OSC 1337). See `docs/iterm.md`.
 
 - `TENOR_API_KEY` (optional)
 - `GIPHY_API_KEY` (required for `--source giphy`)
+- `HEYPSTER_API_KEY` (required for `--source heypster`)
 - `GIFGREP_SOFTWARE_ANIM=1` (force software playback; default on Ghostty)
 - `GIFGREP_CELL_ASPECT=0.5` (tweak preview cell geometry)
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -52,7 +52,7 @@ func (g Globals) toOptions() model.Options {
 }
 
 type SearchCmd struct {
-	Source   string `help:"Source to search." enum:"auto,tenor,giphy" default:"auto"`
+	Source   string `help:"Source to search." enum:"auto,tenor,giphy,heypster" default:"auto"`
 	Max      int    `help:"Max results to fetch." name:"max" short:"m" default:"20"`
 	JSON     bool   `help:"Emit JSON array of results."`
 	Number   bool   `help:"Prefix lines with 1-based index." short:"n"`
@@ -81,7 +81,7 @@ func (c *SearchCmd) Run(ctx *kong.Context, cli *CLI) error {
 }
 
 type TUICmd struct {
-	Source string `help:"Source to search." enum:"auto,tenor,giphy" default:"auto"`
+	Source string `help:"Source to search." enum:"auto,tenor,giphy,heypster" default:"auto"`
 	Max    int    `help:"Max results to fetch." name:"max" short:"m" default:"20"`
 
 	Query []string `arg:"" optional:"" name:"query" help:"Initial query."`

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -195,8 +195,9 @@ func rootHelpExtras() []string {
 		"  gifgrep sheet cat.gif --frames 12 --cols 4 -o sheet.png",
 		"",
 		"Environment:",
-		"  TENOR_API_KEY  optional (defaults to Tenor demo key)",
-		"  GIPHY_API_KEY  required for --source giphy",
+		"  TENOR_API_KEY    optional (defaults to Tenor demo key)",
+		"  GIPHY_API_KEY    required for --source giphy",
+		"  HEYPSTER_API_KEY required for --source heypster",
 	}
 }
 
@@ -213,6 +214,7 @@ func searchHelpExtras() []string {
 		"  gifgrep search --json cats | jq '.[] | .url'",
 		"  gifgrep search --source tenor cats",
 		"  GIPHY_API_KEY=... gifgrep search --source giphy cats",
+		"  HEYPSTER_API_KEY=... gifgrep search --source heypster \"star wars\"",
 	}
 }
 

--- a/internal/search/heypster.go
+++ b/internal/search/heypster.go
@@ -1,0 +1,159 @@
+package search
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/steipete/gifgrep/internal/model"
+)
+
+const (
+	heypsterBaseURL     = "https://heypster-gif.com"
+	heypsterSDKPath     = "/sdk"
+	heypsterPageSize    = 10
+	heypsterDefaultLang = "en"
+)
+
+type heypsterTag struct {
+	ID  int    `json:"id"`
+	Tag string `json:"tag"`
+}
+
+type heypsterGIF struct {
+	ID      int           `json:"id"`
+	GIFMini *string       `json:"gif_mini"`
+	GIF     *string       `json:"gif"`
+	H265    string        `json:"h265"`
+	Tags    []heypsterTag `json:"tags"`
+}
+
+type heypsterGIFPage struct {
+	Data []heypsterGIF `json:"data"`
+}
+
+func fetchHeypsterV1(query string, opts model.Options) ([]model.Result, error) {
+	apiKey := os.Getenv("HEYPSTER_API_KEY")
+	if apiKey == "" {
+		return nil, errors.New("missing HEYPSTER_API_KEY")
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	tags, err := heypsterSearchTags(apiKey, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(tags) == 0 {
+		return nil, nil
+	}
+
+	tag := tags[0]
+	title := strings.ReplaceAll(tag.Tag, "-", " ")
+
+	var out []model.Result
+	pages := (limit + heypsterPageSize - 1) / heypsterPageSize
+	for p := 1; p <= pages; p++ {
+		gifs, err := heypsterFetchGIFs(apiKey, tag.ID, p)
+		if err != nil {
+			return nil, err
+		}
+		for _, g := range gifs {
+			gifURL := heypsterGIFURL(g)
+			if gifURL == "" {
+				continue
+			}
+			var tagNames []string
+			for _, t := range g.Tags {
+				tagNames = append(tagNames, strings.ReplaceAll(t.Tag, "-", " "))
+			}
+			out = append(out, model.Result{
+				ID:         fmt.Sprintf("%d", g.ID),
+				Title:      title,
+				URL:        gifURL,
+				PreviewURL: gifURL,
+				Tags:       tagNames,
+			})
+			if len(out) >= limit {
+				return out, nil
+			}
+		}
+		if len(gifs) < heypsterPageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+func heypsterSearchTags(apiKey, query string) ([]heypsterTag, error) {
+	encoded := url.PathEscape(strings.ToLower(query))
+	reqURL := fmt.Sprintf("%s%s/tags/%s/%s", heypsterBaseURL, heypsterSDKPath, encoded, heypsterDefaultLang)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "gifgrep")
+	req.Header.Set("HEYPSTER-API-KEY", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
+	}
+
+	var tags []heypsterTag
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+func heypsterFetchGIFs(apiKey string, tagID, page int) ([]heypsterGIF, error) {
+	reqURL := fmt.Sprintf("%s%s/gifs-tags/%d?page=%d", heypsterBaseURL, heypsterSDKPath, tagID, page)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "gifgrep")
+	req.Header.Set("HEYPSTER-API-KEY", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("http %d", resp.StatusCode)
+	}
+
+	var page1 heypsterGIFPage
+	if err := json.NewDecoder(resp.Body).Decode(&page1); err != nil {
+		return nil, err
+	}
+	return page1.Data, nil
+}
+
+func heypsterGIFURL(g heypsterGIF) string {
+	if g.GIFMini != nil && *g.GIFMini != "" {
+		return heypsterBaseURL + "/" + *g.GIFMini
+	}
+	if g.GIF != nil && *g.GIF != "" {
+		return heypsterBaseURL + "/" + *g.GIF
+	}
+	return ""
+}

--- a/internal/search/heypster_test.go
+++ b/internal/search/heypster_test.go
@@ -1,0 +1,105 @@
+package search
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gifgrep/internal/model"
+	"github.com/steipete/gifgrep/internal/testutil"
+)
+
+func TestFetchHeypster(t *testing.T) {
+	t.Setenv("HEYPSTER_API_KEY", "test-key")
+	gifData := testutil.MakeTestGIF()
+	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
+		out, err := fetchHeypsterV1("star wars", model.Options{Limit: 1})
+		if err != nil {
+			t.Fatalf("fetchHeypsterV1 failed: %v", err)
+		}
+		if len(out) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(out))
+		}
+		if out[0].URL == "" || out[0].PreviewURL == "" {
+			t.Fatalf("missing URLs")
+		}
+		if out[0].ID != "1" {
+			t.Fatalf("expected ID '1', got %q", out[0].ID)
+		}
+
+		_, err = Search("star wars", model.Options{Limit: 1, Source: "heypster"})
+		if err != nil {
+			t.Fatalf("Search heypster failed: %v", err)
+		}
+	})
+}
+
+func TestFetchHeypsterMissingKey(t *testing.T) {
+	t.Setenv("HEYPSTER_API_KEY", "")
+	if _, err := fetchHeypsterV1("star wars", model.Options{Limit: 1}); err == nil {
+		t.Fatalf("expected missing key error")
+	}
+}
+
+type heypsterNoTagsTransport struct{}
+
+func (tr *heypsterNoTagsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(req.URL.Path, "/sdk/tags/") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader("not found")),
+	}, nil
+}
+
+func TestFetchHeypsterNoTags(t *testing.T) {
+	t.Setenv("HEYPSTER_API_KEY", "test-key")
+	testutil.WithTransport(t, &heypsterNoTagsTransport{}, func() {
+		out, err := fetchHeypsterV1("xyznonexistent", model.Options{Limit: 5})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Fatalf("expected 0 results, got %d", len(out))
+		}
+	})
+}
+
+type heypsterBadJSONTransport struct{}
+
+func (tr *heypsterBadJSONTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("not-json")),
+	}, nil
+}
+
+type heypsterStatusTransport struct{}
+
+func (tr *heypsterStatusTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("oops")),
+	}, nil
+}
+
+func TestFetchHeypsterErrors(t *testing.T) {
+	t.Setenv("HEYPSTER_API_KEY", "test-key")
+	testutil.WithTransport(t, &heypsterBadJSONTransport{}, func() {
+		if _, err := fetchHeypsterV1("star wars", model.Options{Limit: 1}); err == nil {
+			t.Fatalf("expected json error")
+		}
+	})
+	testutil.WithTransport(t, &heypsterStatusTransport{}, func() {
+		if _, err := fetchHeypsterV1("star wars", model.Options{Limit: 1}); err == nil {
+			t.Fatalf("expected status error")
+		}
+	})
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -33,6 +33,8 @@ func Search(query string, opts model.Options) ([]model.Result, error) {
 		return fetchTenorV1(query, opts)
 	case "giphy":
 		return fetchGiphyV1(query, opts)
+	case "heypster":
+		return fetchHeypsterV1(query, opts)
 	default:
 		return nil, fmt.Errorf("unknown source: %s", opts.Source)
 	}

--- a/internal/search/source.go
+++ b/internal/search/source.go
@@ -11,6 +11,9 @@ func ResolveSource(source string) string {
 		if os.Getenv("GIPHY_API_KEY") != "" {
 			return "giphy"
 		}
+		if os.Getenv("HEYPSTER_API_KEY") != "" {
+			return "heypster"
+		}
 		return "tenor"
 	}
 	return source

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -32,6 +32,34 @@ func (t *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body:       io.NopCloser(strings.NewReader(body)),
 		}, nil
+	case "heypster-gif.com":
+		if strings.HasPrefix(req.URL.Path, "/sdk/tags/") {
+			body := `[{"id":42,"tag":"cats"}]`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+		if strings.HasPrefix(req.URL.Path, "/sdk/gifs-tags/") {
+			body := `{"data":[{"id":1,"gif_mini":"gifs/cat1-mini.gif","gif":"gifs/cat1.gif","h265":"gifs/cat1.mp4","tags":[{"id":42,"tag":"cats"}]}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+		if strings.HasPrefix(req.URL.Path, "/gifs/") {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"image/gif"}},
+				Body:       io.NopCloser(bytes.NewReader(t.GIFData)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+		}, nil
 	case "example.test":
 		if req.URL.Path == "/preview.gif" || req.URL.Path == "/full.gif" {
 			return &http.Response{


### PR DESCRIPTION
## Summary

Add [Heypster](https://heypster-gif.com) as a new GIF provider. Heypster is a GIF platform that respects privacy.

- New `--source heypster` option using the Heypster SDK tag API (2-step flow: search tags, then fetch GIFs by tag)
- Credential via `HEYPSTER_API_KEY` environment variable (same pattern as Giphy)
- Auto-resolve picks Heypster when the key is present (after Giphy, before Tenor)
- Full test coverage with mock transport for SDK endpoints

## Changed files

- `internal/search/heypster.go` — provider implementation (tag search + paginated GIF fetch)
- `internal/search/heypster_test.go` — unit tests (success, missing key, no tags, error cases)
- `internal/search/search.go` — add `heypster` case to `Search()` switch
- `internal/search/source.go` — add `HEYPSTER_API_KEY` to auto-resolve
- `internal/app/cli.go` — add `heypster` to `--source` enum
- `internal/app/help.go` — add env var and example to help text
- `internal/testutil/testutil.go` — add Heypster mock routes to `FakeTransport`
- `README.md` — document provider and env var

## Test plan

- [x] `go test ./... -cover` passes
- [x] `HEYPSTER_API_KEY=... gifgrep --source heypster "star wars"` returns GIF URLs
- [x] `gifgrep --source heypster -v "star wars"` shows `source=heypster`
- [x] Missing key returns clear error message
