### PR TITLE
feat(search): replace sunsetting Tenor backend with Klipy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Changes
 
-- Search: replace the Tenor API backend with Klipy. `--source tenor` remains as a compatibility alias,
+- Search: replace the Tenor API backend with KLIPY. `--source tenor` remains as a compatibility alias,
   `--source klipy` is available directly, and `KLIPY_API_KEY` is now required for that provider.
+  Thanks @ZeterMordio.
 
 ## 0.2.3 - 2026-02-04
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.4 — Unreleased
 
+### Changes
+
+- Search: replace the Tenor API backend with Klipy. `--source tenor` remains as a compatibility alias,
+  `--source klipy` is available directly, and `KLIPY_API_KEY` is now required for that provider.
+
 ## 0.2.3 - 2026-02-04
 ### Fixes
 - TUI: after download, preview reloads from the saved full-res GIF.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ go install github.com/steipete/gifgrep/cmd/gifgrep@latest
 - TUI browser: inline preview, quick download, reveal last download.
 - Stills: `still` extracts one frame; `sheet` creates a PNG grid (`--frames`, `--cols`, `--padding`).
 - Color + logging: `--color/--no-color`, `--quiet`, `--verbose`.
-- Providers: `auto` (prefers Giphy when keyed), `tenor`, `giphy`.
+- Providers: `auto` (prefers Giphy when keyed), `klipy`, `tenor` (compatibility alias), `giphy`.
 
 ## Quickstart
 
@@ -60,8 +60,9 @@ gifgrep sheet ./clip.gif --frames 9 --cols 3 -o sheet.png
 
 Select via `--source` (search + TUI):
 
-- `auto` (default): picks Giphy when `GIPHY_API_KEY` is set, else Tenor.
-- `tenor`: uses public demo key if `TENOR_API_KEY` is unset.
+- `auto` (default): picks Giphy when `GIPHY_API_KEY` is set, else Klipy (`KLIPY_API_KEY` required).
+- `klipy`: requires `KLIPY_API_KEY`.
+- `tenor`: backwards-compatible alias for Klipy, using `KLIPY_API_KEY`.
 - `giphy`: requires `GIPHY_API_KEY`.
 
 ## CLI
@@ -103,7 +104,7 @@ iTerm2 uses a different protocol (OSC 1337). See `docs/iterm.md`.
 
 ## Environment
 
-- `TENOR_API_KEY` (optional)
+- `KLIPY_API_KEY` (required for `--source klipy` / `--source tenor`)
 - `GIPHY_API_KEY` (required for `--source giphy`)
 - `GIFGREP_SOFTWARE_ANIM=1` (force software playback; default on Ghostty)
 - `GIFGREP_CELL_ASPECT=0.5` (tweak preview cell geometry)

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
     <div class="wrap">
       <div class="top">
         <div class="brand">
-          <div class="kicker">CLI / TUI · GIPHY (preferred) · Tenor · kitty graphics</div>
+          <div class="kicker">CLI / TUI · GIPHY (preferred) · KLIPY · kitty graphics</div>
           <h1>🧲 gifgrep</h1>
           <p class="tagline">
             <strong>Grep the GIF. Stick the landing.</strong> Scriptable URLs/JSON by default, plus a TUI that previews
@@ -37,8 +37,8 @@
             <div class="pill"><b>tui</b> for arrow-key browsing</div>
           </div>
           <p class="fineprint">
-            If <code>GIPHY_API_KEY</code> is set, gifgrep prefers GIPHY. Otherwise it uses Tenor (with an optional
-            <code>TENOR_API_KEY</code> or Tenor’s public demo key). Inline previews need Kitty or Ghostty.
+            If <code>GIPHY_API_KEY</code> is set, gifgrep prefers GIPHY. Otherwise it uses KLIPY with
+            <code>KLIPY_API_KEY</code>. Inline previews need Kitty or Ghostty.
           </p>
         </div>
 
@@ -53,9 +53,9 @@
               <span class="out">$ </span><span class="cmd">gifgrep cats -m 3</span>
               <span class="caret" aria-hidden="true"></span>
               <span class="out">
-https://media.tenor.com/.../cat-typing.gif
-https://media.tenor.com/.../cat-yes.gif
-https://media.tenor.com/.../cat-stare.gif
+https://.../cat-typing.gif
+https://.../cat-yes.gif
+https://.../cat-stare.gif
 
 $ gifgrep tui "office handshake"
               </span>
@@ -144,9 +144,9 @@ $ gifgrep tui "office handshake"
             <img src="assets/giphy-32.png" width="16" height="16" alt="GIPHY" />
             GIPHY
           </a>
-          <a href="https://tenor.com">Tenor</a>
+          <a href="https://klipy.com">KLIPY</a>
         </div>
-        <div>© <a href="https://steipete.me">Peter Steinberger</a> · MIT · GIFs courtesy GIPHY + Tenor</div>
+        <div>© <a href="https://steipete.me">Peter Steinberger</a> · MIT · GIFs courtesy GIPHY + KLIPY</div>
       </div>
     </div>
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -52,7 +52,7 @@ func (g Globals) toOptions() model.Options {
 }
 
 type SearchCmd struct {
-	Source   string `help:"Source to search." enum:"auto,tenor,giphy" default:"auto"`
+	Source   string `help:"Source to search." enum:"auto,klipy,tenor,giphy" default:"auto"`
 	Max      int    `help:"Max results to fetch." name:"max" short:"m" default:"20"`
 	JSON     bool   `help:"Emit JSON array of results."`
 	Number   bool   `help:"Prefix lines with 1-based index." short:"n"`
@@ -81,7 +81,7 @@ func (c *SearchCmd) Run(ctx *kong.Context, cli *CLI) error {
 }
 
 type TUICmd struct {
-	Source string `help:"Source to search." enum:"auto,tenor,giphy" default:"auto"`
+	Source string `help:"Source to search." enum:"auto,klipy,tenor,giphy" default:"auto"`
 	Max    int    `help:"Max results to fetch." name:"max" short:"m" default:"20"`
 
 	Query []string `arg:"" optional:"" name:"query" help:"Initial query."`

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRunSearchOutput(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	gifData := testutil.MakeTestGIF()
 	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
 		var stdout bytes.Buffer
@@ -28,6 +29,7 @@ func TestRunSearchOutput(t *testing.T) {
 }
 
 func TestRunSearchJSON(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	gifData := testutil.MakeTestGIF()
 	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
 		var stdout bytes.Buffer

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -195,7 +195,7 @@ func rootHelpExtras() []string {
 		"  gifgrep sheet cat.gif --frames 12 --cols 4 -o sheet.png",
 		"",
 		"Environment:",
-		"  TENOR_API_KEY  optional (defaults to Tenor demo key)",
+		"  KLIPY_API_KEY  required for --source klipy/tenor",
 		"  GIPHY_API_KEY  required for --source giphy",
 	}
 }
@@ -211,7 +211,8 @@ func searchHelpExtras() []string {
 		"  gifgrep cats | head -n 5",
 		"  gifgrep cats --download --max 1 --format url",
 		"  gifgrep search --json cats | jq '.[] | .url'",
-		"  gifgrep search --source tenor cats",
+		"  KLIPY_API_KEY=... gifgrep search --source klipy cats",
+		"  KLIPY_API_KEY=... gifgrep search --source tenor cats",
 		"  GIPHY_API_KEY=... gifgrep search --source giphy cats",
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -12,25 +12,27 @@ import (
 	"github.com/steipete/gifgrep/internal/model"
 )
 
-type tenorV1Response struct {
-	Results []struct {
-		ID                 string               `json:"id"`
-		Title              string               `json:"title"`
-		ContentDescription string               `json:"content_description"`
-		Tags               []string             `json:"tags"`
-		Media              []map[string]mediaV1 `json:"media"`
-	} `json:"results"`
+type klipyV2Response struct {
+	Results []klipyV2Result `json:"results"`
 }
 
-type mediaV1 struct {
+type klipyV2Result struct {
+	ID                 string             `json:"id"`
+	Title              string             `json:"title"`
+	ContentDescription string             `json:"content_description"`
+	Tags               []string           `json:"tags"`
+	MediaFormats       map[string]mediaV2 `json:"media_formats"`
+}
+
+type mediaV2 struct {
 	URL  string `json:"url"`
 	Dims []int  `json:"dims"`
 }
 
 func Search(query string, opts model.Options) ([]model.Result, error) {
 	switch ResolveSource(opts.Source) {
-	case "tenor":
-		return fetchTenorV1(query, opts)
+	case "klipy":
+		return fetchKlipyV2(query, opts)
 	case "giphy":
 		return fetchGiphyV1(query, opts)
 	default:
@@ -38,13 +40,10 @@ func Search(query string, opts model.Options) ([]model.Result, error) {
 	}
 }
 
-func fetchTenorV1(query string, opts model.Options) ([]model.Result, error) {
-	apiKey := os.Getenv("TENOR_API_KEY")
+func fetchKlipyV2(query string, opts model.Options) ([]model.Result, error) {
+	apiKey := os.Getenv("KLIPY_API_KEY")
 	if apiKey == "" {
-		apiKey = "LIVDSRZULELA"
-	}
-	if apiKey == "" {
-		return nil, errors.New("missing TENOR_API_KEY")
+		return nil, errors.New("missing KLIPY_API_KEY")
 	}
 	limit := opts.Limit
 	if limit <= 0 {
@@ -56,8 +55,9 @@ func fetchTenorV1(query string, opts model.Options) ([]model.Result, error) {
 	params.Set("key", apiKey)
 	params.Set("limit", fmt.Sprintf("%d", limit))
 	params.Set("contentfilter", "low")
+	params.Set("media_filter", "gif,tinygif,mediumgif,nanogif,preview")
 
-	reqURL := "https://api.tenor.com/v1/search?" + params.Encode()
+	reqURL := "https://api.klipy.com/v2/search?" + params.Encode()
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
@@ -76,13 +76,14 @@ func fetchTenorV1(query string, opts model.Options) ([]model.Result, error) {
 		return nil, fmt.Errorf("http %d", resp.StatusCode)
 	}
 
-	var parsed tenorV1Response
+	var parsed klipyV2Response
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, err
 	}
 
 	out := make([]model.Result, 0, len(parsed.Results))
-	for _, r := range parsed.Results {
+	for i := range parsed.Results {
+		r := &parsed.Results[i]
 		title := r.Title
 		if title == "" {
 			title = r.ContentDescription
@@ -90,43 +91,43 @@ func fetchTenorV1(query string, opts model.Options) ([]model.Result, error) {
 		if title == "" {
 			title = r.ID
 		}
-		gifURL := ""
-		preview := ""
-		width := 0
-		height := 0
-		if len(r.Media) > 0 {
-			media := r.Media[0]
-			if m, ok := media["gif"]; ok {
-				gifURL = m.URL
-				if len(m.Dims) == 2 {
-					width, height = m.Dims[0], m.Dims[1]
-				}
-			}
-			if m, ok := media["tinygif"]; ok {
-				preview = m.URL
-				if gifURL == "" {
-					gifURL = m.URL
-					if len(m.Dims) == 2 {
-						width, height = m.Dims[0], m.Dims[1]
-					}
-				}
-			}
-			if preview == "" {
-				preview = gifURL
-			}
-		}
-		if gifURL == "" {
+
+		gifMedia, ok := mediaFormat(r.MediaFormats, "gif", "mediumgif", "tinygif", "nanogif", "preview")
+		if !ok || gifMedia.URL == "" {
 			continue
 		}
+		previewMedia, ok := mediaFormat(r.MediaFormats, "tinygif", "nanogif", "preview", "mediumgif", "gif")
+		if !ok || previewMedia.URL == "" {
+			previewMedia = gifMedia
+		}
+		width, height := mediaDims(gifMedia)
+
 		out = append(out, model.Result{
 			ID:         r.ID,
 			Title:      title,
-			URL:        gifURL,
-			PreviewURL: preview,
+			URL:        gifMedia.URL,
+			PreviewURL: previewMedia.URL,
 			Tags:       r.Tags,
 			Width:      width,
 			Height:     height,
 		})
 	}
 	return out, nil
+}
+
+func mediaFormat(formats map[string]mediaV2, names ...string) (mediaV2, bool) {
+	for _, name := range names {
+		media, ok := formats[name]
+		if ok && media.URL != "" {
+			return media, true
+		}
+	}
+	return mediaV2{}, false
+}
+
+func mediaDims(media mediaV2) (int, int) {
+	if len(media.Dims) != 2 {
+		return 0, 0
+	}
+	return media.Dims[0], media.Dims[1]
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -10,21 +10,69 @@ import (
 	"github.com/steipete/gifgrep/internal/testutil"
 )
 
-func TestFetchTenorAndGIF(t *testing.T) {
+func TestFetchKlipyAndGIF(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	gifData := testutil.MakeTestGIF()
 	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
 		if _, err := Search("cats", model.Options{Source: "nope"}); err == nil {
 			t.Fatalf("expected unknown source error")
 		}
-		out, err := fetchTenorV1("cats", model.Options{Limit: 1})
+		out, err := fetchKlipyV2("cats", model.Options{Limit: 1})
 		if err != nil {
-			t.Fatalf("fetchTenorV1 failed: %v", err)
+			t.Fatalf("fetchKlipyV2 failed: %v", err)
 		}
 		if len(out) != 1 {
 			t.Fatalf("expected 1 result")
 		}
 		if out[0].PreviewURL == "" || out[0].URL == "" {
 			t.Fatalf("missing URLs")
+		}
+	})
+}
+
+type klipyRequestTransport struct {
+	t *testing.T
+}
+
+func (rt *klipyRequestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.t.Helper()
+	if req.URL.Scheme != "https" || req.URL.Host != "api.klipy.com" || req.URL.Path != "/v2/search" {
+		rt.t.Fatalf("unexpected Klipy URL: %s", req.URL.String())
+	}
+	q := req.URL.Query()
+	if q.Get("key") != "test-key" || q.Get("q") != "cats" || q.Get("limit") != "7" {
+		rt.t.Fatalf("unexpected Klipy query: %s", req.URL.RawQuery)
+	}
+	if q.Get("contentfilter") != "low" {
+		rt.t.Fatalf("expected contentfilter=low, got %q", q.Get("contentfilter"))
+	}
+	if q.Get("media_filter") == "" {
+		rt.t.Fatalf("expected media_filter")
+	}
+
+	body := `{"results":[{"id":"1","content_description":"Cat Desc","tags":["cat"],"media_formats":{"mediumgif":{"url":"https://example.test/full.gif","dims":[200,100]},"nanogif":{"url":"https://example.test/preview.gif","dims":[50,25]}}}]}`
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestFetchKlipyRequestAndFallbacks(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "test-key")
+	testutil.WithTransport(t, &klipyRequestTransport{t: t}, func() {
+		results, err := fetchKlipyV2("cats", model.Options{Limit: 7})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected one result, got %d", len(results))
+		}
+		if results[0].Title != "Cat Desc" {
+			t.Fatalf("expected content description title fallback, got %q", results[0].Title)
+		}
+		if results[0].URL != "https://example.test/full.gif" || results[0].PreviewURL != "https://example.test/preview.gif" {
+			t.Fatalf("unexpected URLs: %#v", results[0])
 		}
 	})
 }
@@ -51,9 +99,9 @@ func TestFetchGiphy(t *testing.T) {
 	})
 }
 
-type badTenorTransport struct{}
+type badKlipyTransport struct{}
 
-func (t *badTenorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (t *badKlipyTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	body := "not-json"
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -62,23 +110,25 @@ func (t *badTenorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-type statusTenorTransport struct{}
+type statusKlipyTransport struct{}
 
-func (t *statusTenorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (t *statusKlipyTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusInternalServerError,
 		Body:       io.NopCloser(strings.NewReader("oops")),
 	}, nil
 }
 
-func TestFetchTenorErrors(t *testing.T) {
-	testutil.WithTransport(t, &badTenorTransport{}, func() {
-		if _, err := fetchTenorV1("cats", model.Options{Limit: 1}); err == nil {
+func TestFetchKlipyErrors(t *testing.T) {
+	testutil.WithTransport(t, &badKlipyTransport{}, func() {
+		t.Setenv("KLIPY_API_KEY", "test-key")
+		if _, err := fetchKlipyV2("cats", model.Options{Limit: 1}); err == nil {
 			t.Fatalf("expected json error")
 		}
 	})
-	testutil.WithTransport(t, &statusTenorTransport{}, func() {
-		if _, err := fetchTenorV1("cats", model.Options{Limit: 1}); err == nil {
+	testutil.WithTransport(t, &statusKlipyTransport{}, func() {
+		t.Setenv("KLIPY_API_KEY", "test-key")
+		if _, err := fetchKlipyV2("cats", model.Options{Limit: 1}); err == nil {
 			t.Fatalf("expected status error")
 		}
 	})
@@ -87,7 +137,7 @@ func TestFetchTenorErrors(t *testing.T) {
 type noMediaTransport struct{}
 
 func (t *noMediaTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
-	body := `{"results":[{"id":"1","title":"No Media","media":[]},{"id":"2","title":"Gif Only","media":[{"gif":{"url":"https://example.test/full.gif","dims":[10,5]}}]}]}`
+	body := `{"results":[{"id":"1","title":"No Media","media_formats":{}},{"id":"2","title":"Gif Only","media_formats":{"gif":{"url":"https://example.test/full.gif","dims":[10,5]}}}]}`
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
@@ -95,9 +145,10 @@ func (t *noMediaTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	}, nil
 }
 
-func TestFetchTenorMediaFallbacks(t *testing.T) {
+func TestFetchKlipyMediaFallbacks(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	testutil.WithTransport(t, &noMediaTransport{}, func() {
-		results, err := fetchTenorV1("cats", model.Options{Limit: 2})
+		results, err := fetchKlipyV2("cats", model.Options{Limit: 2})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -108,4 +159,26 @@ func TestFetchTenorMediaFallbacks(t *testing.T) {
 			t.Fatalf("expected preview fallback")
 		}
 	})
+}
+
+func TestFetchKlipyMissingKey(t *testing.T) {
+	t.Setenv("KLIPY_API_KEY", "")
+	if _, err := fetchKlipyV2("cats", model.Options{Limit: 1}); err == nil || !strings.Contains(err.Error(), "KLIPY_API_KEY") {
+		t.Fatalf("expected missing KLIPY_API_KEY error, got %v", err)
+	}
+}
+
+func TestResolveSource(t *testing.T) {
+	t.Setenv("GIPHY_API_KEY", "")
+	if got := ResolveSource("tenor"); got != "klipy" {
+		t.Fatalf("expected tenor alias to resolve to klipy, got %q", got)
+	}
+	if got := ResolveSource("auto"); got != "klipy" {
+		t.Fatalf("expected auto fallback to klipy, got %q", got)
+	}
+
+	t.Setenv("GIPHY_API_KEY", "test-key")
+	if got := ResolveSource("auto"); got != "giphy" {
+		t.Fatalf("expected auto with giphy key to resolve to giphy, got %q", got)
+	}
 }

--- a/internal/search/source.go
+++ b/internal/search/source.go
@@ -11,7 +11,10 @@ func ResolveSource(source string) string {
 		if os.Getenv("GIPHY_API_KEY") != "" {
 			return "giphy"
 		}
-		return "tenor"
+		return "klipy"
+	}
+	if source == "tenor" {
+		return "klipy"
 	}
 	return source
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -18,8 +18,8 @@ type FakeTransport struct {
 
 func (t *FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch req.URL.Host {
-	case "api.tenor.com":
-		body := `{"results":[{"id":"1","title":"Cat One","content_description":"","tags":["cat","fun"],"media":[{"gif":{"url":"https://example.test/full.gif","dims":[200,100]},"tinygif":{"url":"https://example.test/preview.gif","dims":[50,25]}}]}]}`
+	case "api.klipy.com":
+		body := `{"results":[{"id":"1","title":"Cat One","content_description":"","tags":["cat","fun"],"media_formats":{"gif":{"url":"https://example.test/full.gif","dims":[200,100]},"tinygif":{"url":"https://example.test/preview.gif","dims":[50,25]}}}]}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},

--- a/internal/tui/env_test.go
+++ b/internal/tui/env_test.go
@@ -45,6 +45,8 @@ func TestRunTUIWithQuit(t *testing.T) {
 
 func TestRunTUIWithSearch(t *testing.T) {
 	t.Setenv("GIFGREP_INLINE", "kitty")
+	t.Setenv("GIFGREP_TUI_PREFETCH_MAX_BYTES", "0")
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	gifData := testutil.MakeTestGIF()
 	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
 		env := Env{

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -695,6 +695,7 @@ func drawStatus(out *bufio.Writer, state *appState, layout layout) {
 	}
 	source := search.ResolveSource(state.opts.Source)
 	showGiphyAttribution := source == "giphy"
+	showKlipyAttribution := source == "klipy"
 	showGiphyIcon := showGiphyAttribution && state.inline == termcaps.InlineKitty
 	logoCols := 2
 	logoRows := 1
@@ -705,6 +706,8 @@ func drawStatus(out *bufio.Writer, state *appState, layout layout) {
 	line := formatStatusLine(state.useColor, status)
 	if showGiphyAttribution {
 		line += styleIf(state.useColor, " · Powered by GIPHY", "\x1b[90m")
+	} else if showKlipyAttribution {
+		line += styleIf(state.useColor, " · Powered by KLIPY", "\x1b[90m")
 	}
 	writeLineAt(out, layout.statusRow, 1, line, statusWidth)
 	if showGiphyIcon && layout.cols >= logoCols {
@@ -734,15 +737,19 @@ func formatStatusLine(useColor bool, status string) string {
 }
 
 func drawSearch(out *bufio.Writer, state *appState, layout layout) {
-	pill := "[Search]"
+	label := "Search"
+	if search.ResolveSource(state.opts.Source) == "klipy" {
+		label = "Search KLIPY"
+	}
+	pill := "[" + label + "]"
 	query := state.query
 	if state.useColor {
 		bg := "\x1b[48;5;236m"
 		if state.mode == modeQuery {
-			pill = styleIf(true, " Search ", bg, "\x1b[1m", "\x1b[33m")
+			pill = styleIf(true, " "+label+" ", bg, "\x1b[1m", "\x1b[33m")
 			query += styleIf(true, "▍", "\x1b[36m")
 		} else {
-			pill = styleIf(true, " Search ", bg, "\x1b[90m")
+			pill = styleIf(true, " "+label+" ", bg, "\x1b[90m")
 		}
 	}
 	searchLine := pill + " " + query

--- a/internal/tui/tui_more_test.go
+++ b/internal/tui/tui_more_test.go
@@ -70,9 +70,9 @@ func TestRunTUIWithSizeError(t *testing.T) {
 	}
 }
 
-type emptyTenorTransport struct{}
+type emptyKlipyTransport struct{}
 
-func (t *emptyTenorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (t *emptyKlipyTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	body := `{"results":[]}`
 	return &http.Response{
 		StatusCode: http.StatusOK,
@@ -83,7 +83,8 @@ func (t *emptyTenorTransport) RoundTrip(_ *http.Request) (*http.Response, error)
 
 func TestRunTUIWithEmptyResultsAndSignal(t *testing.T) {
 	t.Setenv("GIFGREP_INLINE", "kitty")
-	testutil.WithTransport(t, &emptyTenorTransport{}, func() {
+	t.Setenv("KLIPY_API_KEY", "test-key")
+	testutil.WithTransport(t, &emptyKlipyTransport{}, func() {
 		sigs := make(chan os.Signal, 1)
 		sigs <- os.Interrupt
 		env := Env{

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -48,6 +48,8 @@ func TestEnsureVisible(t *testing.T) {
 }
 
 func TestHandleInputAndLoad(t *testing.T) {
+	t.Setenv("GIFGREP_TUI_PREFETCH_MAX_BYTES", "0")
+	t.Setenv("KLIPY_API_KEY", "test-key")
 	gifData := testutil.MakeTestGIF()
 	testutil.WithTransport(t, &testutil.FakeTransport{GIFData: gifData}, func() {
 		state := &appState{
@@ -203,11 +205,14 @@ func TestRenderAndLines(t *testing.T) {
 	if strings.Contains(text, "\x1b_G") {
 		t.Fatalf("unexpected kitty graphics data")
 	}
+	if !strings.Contains(text, "Powered by KLIPY") {
+		t.Fatalf("missing KLIPY attribution")
+	}
 
 	buf.Reset()
 	render(state, out, 20, 90)
 	_ = out.Flush()
-	if !strings.Contains(buf.String(), "[Search]") {
+	if !strings.Contains(buf.String(), "[Search KLIPY]") {
 		t.Fatalf("expected search line")
 	}
 


### PR DESCRIPTION
## Summary

Tenor is one of gifgrep's two search providers, and Google has announced the Tenor API will be fully decommissioned on June 30, 2026. This moves the Tenor-backed search path to Klipy, while keeping `--source tenor` working as a compatibility alias.

## Why

`auto` currently falls back to Tenor when `GIPHY_API_KEY` is not set, so default search will break for users without Giphy credentials once Tenor shuts down.

Klipy documents a Tenor migration path using `api.klipy.com` and a Klipy API key:
https://docs.klipy.com/migrate-from-tenor.md

Klipy also describes the team as including ex-Tenor founder, leadership, and tech team members:
https://www.linkedin.com/company/klipyco

## Changes

- Add Klipy v2 search via `https://api.klipy.com/v2/search`
- Add `--source klipy`
- Keep `--source tenor` as an alias resolving to Klipy
- Update `auto` fallback to Klipy when Giphy is not configured
- Replace `TENOR_API_KEY` docs/help with `KLIPY_API_KEY`
- Keep Giphy behavior unchanged
- Add Klipy attribution in the TUI
- Update mocks and regression tests

## Validation

- `make test`
- `make lint`
- `go test -race ./...`
- `go build ./...`
- Live smoke with `KLIPY_API_KEY` for both `--source klipy` and the `--source tenor` alias
