### PR TITLE
chore(deps): update Go toolchain and runewidth patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.2 - Unreleased
 
+### Dependencies
+
+- Update the Go toolchain to 1.27.1 and go-runewidth to 0.0.29, retaining Go 1.25 as the minimum supported version.
+
 ## 0.3.1 - 2026-08-28
 
 ### Highlights

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/steipete/gifgrep
 
 go 1.25.0
 
-toolchain go1.27.0
+toolchain go1.27.1
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/mattn/go-runewidth v0.0.28
+	github.com/mattn/go-runewidth v0.0.29
 	github.com/mattn/go-sixel v0.0.12
 	golang.org/x/term v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/mattn/go-runewidth v0.0.28 h1:rPyg2ybwEKPebvpzVWe1gKBkH8EQFkxO4Y0hjBeLaBU=
-github.com/mattn/go-runewidth v0.0.28/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
+github.com/mattn/go-runewidth v0.0.29 h1:3oGF3R/S2N9DQ3ptftzVIvg2eicmojCzlwBEmqEPDfQ=
+github.com/mattn/go-runewidth v0.0.29/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/mattn/go-sixel v0.0.12 h1:pQadX/oJ4fhSi6RnFHggWELW1TvADrQP9b+Kdx1wNzs=
 github.com/mattn/go-sixel v0.0.12/go.mod h1:Z5QJ/vRbnpAl4CTN0NZ0mzURdMccsG7rpGZ5eJfZ6ys=
 github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=


### PR DESCRIPTION
Refresh the Go toolchain from 1.27.0 to 1.27.1 and go-runewidth from 0.0.28 to 0.0.29. These are patch updates; the `go 1.25.0` minimum stays unchanged and the full test suite passes under that minimum. The module checksums and unreleased changelog are updated together.

The dependency audit found Playwright 1.62.1, gofumpt 0.11.0, golangci-lint 2.13.2, and the existing GitHub Actions major tags current. No product behavior or configuration changes are included.

Validation:

- Go 1.27.1: `make test check build`, `golangci-lint run`, gofumpt 0.11.0 formatting check, and `go mod verify` passed.
- `GOTOOLCHAIN=go1.25.0 go test ./...` passed.
- Built CLI: help, local and HTTP GIF frame extraction, byte-identical file/stdout PNG output, a four-frame contact sheet, and invalid frame-count rejection passed.
- `make termcaps-e2e` passed all 16 deterministic and PTY checks.
- `npm audit --package-lock-only --json` reported zero vulnerabilities.
