### PR TITLE
docs: prepare download cache release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## 0.3.3 - Unreleased
+## 0.4.0 - Unreleased
+
+### Highlights
+
+Reuse downloaded GIFs across CLI and TUI sessions with an opt-in persistent cache.
+
+### Features
+
+- Downloads: add `--cache` / `GIFGREP_CACHE` with a configurable location, seven-day expiry, and a 100 MiB size budget; keep explicit saves in `~/Downloads`. Thanks @grabear (#10).
+
+### Fixes
+
+- Downloads: reserve filenames atomically so simultaneous saves cannot overwrite each other.
 
 ## 0.3.2 - 2026-09-05
 


### PR DESCRIPTION
Prepare the Unreleased notes for the persistent download cache and concurrent-save fix. Recommend 0.4.0 because this adds persistent reuse across CLI and TUI sessions; keep released sections unchanged and credit @grabear for #10.

Land this after #15, the independent download-cache implementation PR. This PR only changes CHANGELOG.md; it does not bump the runtime version or publish a release. Dependency checks found no applicable updates.

Validation: `git diff --check` and clean autoreview. The implementation PR carries the full suite and built-binary CLI/TUI proof; exact-head CI is required here as well.
