### PR TITLE
chore(deps): refresh terminal width and formatting tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install tools
         run: |
-          go install mvdan.cc/gofumpt@v0.11.0
+          go install mvdan.cc/gofumpt@v0.12.0
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
 
       - name: Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 0.4.1 - Unreleased
 
+### Highlights
+
+Type and edit Unicode search queries in the TUI without losing accented letters, CJK text, or emoji.
+
+### Fixes
+
+- TUI: accept UTF-8 search input and remove complete Unicode code points with Backspace instead of dropping or corrupting non-ASCII text.
+
+### Dependencies
+
+- Update go-runewidth to 0.0.30 and the CI formatter to gofumpt 0.12.0, retaining Go 1.25 as the minimum supported version.
+
 ## 0.4.0 - 2026-09-07
 
 ### Highlights

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.27.1
 
 require (
 	github.com/alecthomas/kong v1.16.1
-	github.com/mattn/go-runewidth v0.0.29
+	github.com/mattn/go-runewidth v0.0.30
 	github.com/mattn/go-sixel v0.0.12
 	golang.org/x/term v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/mattn/go-runewidth v0.0.29 h1:3oGF3R/S2N9DQ3ptftzVIvg2eicmojCzlwBEmqEPDfQ=
-github.com/mattn/go-runewidth v0.0.29/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
+github.com/mattn/go-runewidth v0.0.30 h1:+KUuiDA4fF0R1p5FeueHefjDm+GIM+kWfFnDjybOPgk=
+github.com/mattn/go-runewidth v0.0.30/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/mattn/go-sixel v0.0.12 h1:pQadX/oJ4fhSi6RnFHggWELW1TvADrQP9b+Kdx1wNzs=
 github.com/mattn/go-sixel v0.0.12/go.mod h1:Z5QJ/vRbnpAl4CTN0NZ0mzURdMccsG7rpGZ5eJfZ6ys=
 github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=


### PR DESCRIPTION
Refresh go-runewidth 0.0.29 → 0.0.30 and the CI formatter gofumpt 0.11.0 → 0.12.0. Keep the Go 1.25 application minimum: current x/term 0.46.0 and x/sys 0.48.0 require Go 1.26, so those updates are held. CI already uses Go 1.27.1 and supports the new formatter. Playwright, golangci-lint, and the configured GitHub Action major tags are current.

This is the final notes PR for the sweep. Merge it after the Unicode TUI fix in #17; it owns the entire 0.4.1 Unreleased section, including that fix's Highlights and changelog bullet. Both PR branches are independently based on main and have disjoint files.

Validation: full `go test ./... -cover`, `go vet ./...`, gofumpt 0.12.0 with no formatting changes, and golangci-lint 2.13.2 (0 issues). The real built CLI produces valid PNGs for `still` and `sheet`, and stdout PNG output matches file output. A PTY smoke verifies ASCII query editing, `q`, Backspace, Ctrl-C, and terminal restoration. Unicode behavior is proved in the sibling fix. Local Codex autoreview is clean; exact-head CI and branch review will be posted below.

Recommend patch 0.4.1 after both PRs land. No tag or release is created here.
