### PR TITLE
fix: exit the TUI when terminal input closes

### DIFF
--- a/internal/app/main_entry_test.go
+++ b/internal/app/main_entry_test.go
@@ -76,7 +76,11 @@ func TestRunArgs(t *testing.T) {
 		}
 
 		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
+		w, err := os.CreateTemp(t.TempDir(), "stdout")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = w.Close() }()
 		os.Stdout = w
 		t.Cleanup(func() {
 			os.Stdout = oldStdout
@@ -87,7 +91,10 @@ func TestRunArgs(t *testing.T) {
 		if code != 0 {
 			t.Fatalf("expected exit 0")
 		}
-		out, _ := io.ReadAll(r)
+		out, err := os.ReadFile(w.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
 		if !bytes.HasPrefix(out, []byte{0x89, 'P', 'N', 'G'}) {
 			t.Fatalf("expected png output")
 		}

--- a/internal/tui/input_eof_test.go
+++ b/internal/tui/input_eof_test.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInputEOFClosesEventStream(t *testing.T) {
+	events, stop := setupInputReader(strings.NewReader(""))
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+	done := make(chan bool, 1)
+	go func() { done <- handleEvents(nil, bufio.NewWriter(io.Discard), nil, events, stop, nil, ticker) }()
+	select {
+	case quit := <-done:
+		if !quit {
+			t.Fatal("EOF did not quit")
+		}
+	case <-time.After(time.Second):
+		close(stop)
+		t.Fatal("EOF left event loop waiting")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -111,7 +111,10 @@ func setupSignals(env Env) <-chan os.Signal {
 func setupInputReader(in io.Reader) (chan inputEvent, chan struct{}) {
 	inputCh := make(chan inputEvent, 16)
 	stopCh := make(chan struct{})
-	go readInput(in, inputCh, stopCh)
+	go func() {
+		defer close(inputCh)
+		readInput(in, inputCh, stopCh)
+	}()
 	return inputCh, stopCh
 }
 
@@ -223,7 +226,11 @@ func handleEvents(state *appState, out *bufio.Writer, prefetchCh chan prefetchRe
 	case <-sigs:
 		close(stopCh)
 		return true
-	case ev := <-inputCh:
+	case ev, ok := <-inputCh:
+		if !ok {
+			close(stopCh)
+			return true
+		}
 		if handleInput(state, ev, out, prefetchCh) {
 			close(stopCh)
 			return true


### PR DESCRIPTION
Closing terminal input now closes the event stream and exits the TUI instead of leaving the event loop waiting indefinitely. Capture PNG test output in a temporary file so test output cannot fill an unread pipe.

Validation: EOF regression test, ten full-suite runs and lint pass. The earlier audit hang was intermittent; this fixes a reproduced EOF wait and removes the remaining pipe risk without claiming the original hang was conclusively identified.