### PR TITLE
refactor: separate CLI output and share provider requests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,15 +43,11 @@ linters:
       min-complexity: 30
     gocritic:
       enabled-checks:
-        - appendAssign
-        - badCond
         - boolExprSimplify
         - emptyStringTest
         - evalOrder
-        - ifElseChain
         - octalLiteral
         - rangeValCopy
-        - unslice
         - whyNoLint
 
 formatters:

--- a/gifdecode/benchmark_test.go
+++ b/gifdecode/benchmark_test.go
@@ -5,8 +5,7 @@ import "testing"
 func BenchmarkDecodeSmall(b *testing.B) {
 	data := makeTestGIF(4)
 	opts := DefaultOptions()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Decode(data, opts); err != nil {
 			b.Fatalf("decode failed: %v", err)
 		}
@@ -16,8 +15,7 @@ func BenchmarkDecodeSmall(b *testing.B) {
 func BenchmarkDecodeMedium(b *testing.B) {
 	data := makeMediumGIF()
 	opts := DefaultOptions()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := Decode(data, opts); err != nil {
 			b.Fatalf("decode failed: %v", err)
 		}
@@ -39,8 +37,7 @@ func BenchmarkDecodeFixtures(b *testing.B) {
 	for _, fixture := range fixtures {
 		data := readFixture(b, fixture.file)
 		b.Run(fixture.name, func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := Decode(data, opts); err != nil {
 					b.Fatalf("decode failed: %v", err)
 				}

--- a/gifdecode/decode.go
+++ b/gifdecode/decode.go
@@ -178,9 +178,7 @@ func encodePNG(img image.Image) ([]byte, error) {
 	if err := pngEncoder.Encode(buf, img); err != nil {
 		return nil, err
 	}
-	out := make([]byte, buf.Len())
-	copy(out, buf.Bytes())
-	return out, nil
+	return bytes.Clone(buf.Bytes()), nil
 }
 
 func readAllLimit(r io.Reader, maxBytes int64) ([]byte, error) {

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -1,23 +1,14 @@
 package app
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/steipete/gifgrep/internal/download"
 	"github.com/steipete/gifgrep/internal/model"
 	"github.com/steipete/gifgrep/internal/reveal"
-	"github.com/steipete/gifgrep/internal/search"
-	"github.com/steipete/gifgrep/internal/termcaps"
 	"github.com/steipete/gifgrep/internal/tui"
-	"golang.org/x/term"
 )
 
 type CLI struct {
@@ -161,163 +152,4 @@ func (c *SheetCmd) Run(_ *kong.Context, cli *CLI) error {
 		}
 	}
 	return nil
-}
-
-func runSearch(stdout io.Writer, stderr io.Writer, opts model.Options, query string) error {
-	if strings.TrimSpace(query) == "" {
-		return errors.New("missing query")
-	}
-	logSearchConfig(stderr, opts)
-
-	results, err := search.Search(query, opts)
-	if err != nil {
-		return err
-	}
-
-	if err := downloadSearchResults(results, opts, stderr); err != nil {
-		return err
-	}
-
-	format := resolveOutputFormat(opts, stdout)
-	out := bufio.NewWriter(stdout)
-	defer func() { _ = out.Flush() }()
-	if format == formatJSON {
-		enc := json.NewEncoder(out)
-		enc.SetIndent("", "  ")
-		return enc.Encode(results)
-	}
-
-	useColor := shouldUseColor(opts, stdout)
-	thumbs := thumbsProtocol(opts, stdout, format)
-	termCols := termColumns(stdout, thumbs)
-
-	writeSearchResults(out, opts, useColor, thumbs, results, termCols, format)
-	return nil
-}
-
-func logSearchConfig(stderr io.Writer, opts model.Options) {
-	if opts.Verbose > 0 && !opts.Quiet {
-		_, _ = fmt.Fprintf(stderr, "source=%s max=%d\n", search.ResolveSource(opts.Source), opts.Limit)
-	}
-}
-
-func downloadSearchResults(results []model.Result, opts model.Options, stderr io.Writer) error {
-	if !opts.Download {
-		return nil
-	}
-
-	var lastSaved string
-	for _, res := range results {
-		if res.URL == "" {
-			continue
-		}
-		savedPath, err := download.ToDownloads(res, opts.Cache)
-		if err != nil {
-			return err
-		}
-		lastSaved = savedPath
-		if opts.Verbose > 0 && !opts.Quiet {
-			_, _ = fmt.Fprintf(stderr, "saved %s\n", savedPath)
-		}
-	}
-	if opts.Reveal && lastSaved != "" {
-		return reveal.Reveal(lastSaved)
-	}
-	return nil
-}
-
-func termColumns(w io.Writer, thumbs termcaps.InlineProtocol) int {
-	if thumbs == termcaps.InlineNone {
-		return 0
-	}
-	f, ok := w.(*os.File)
-	if !ok {
-		return 0
-	}
-	cols, _, err := term.GetSize(int(f.Fd()))
-	if err != nil || cols <= 0 {
-		return 0
-	}
-	return cols
-}
-
-func writeSearchResults(out *bufio.Writer, opts model.Options, useColor bool, thumbs termcaps.InlineProtocol, results []model.Result, termCols int, format outputFormat) {
-	switch format {
-	case formatPlain:
-		renderPlain(out, opts, useColor, thumbs, results, termCols)
-		return
-	case formatURL:
-		for i, res := range results {
-			url := res.URL
-			if opts.Number {
-				_, _ = fmt.Fprintf(out, "%d\t%s\n", i+1, url)
-				continue
-			}
-			_, _ = fmt.Fprintln(out, url)
-		}
-		return
-	case formatMD:
-		for i, res := range results {
-			title := normalizeTitle(res)
-			url := res.URL
-			prefix := "- "
-			if opts.Number {
-				prefix = fmt.Sprintf("%d. ", i+1)
-			}
-			_, _ = fmt.Fprintf(out, "%s[%s](%s)\n", prefix, title, url)
-		}
-		return
-	case formatComment:
-		for i, res := range results {
-			title := normalizeTitle(res)
-			url := res.URL
-			if opts.Number {
-				_, _ = fmt.Fprintf(out, "%d\t%s  # %s\n", i+1, url, title)
-				continue
-			}
-			_, _ = fmt.Fprintf(out, "%s  # %s\n", url, title)
-		}
-		return
-	case formatJSON:
-		// handled by caller
-		return
-	case formatTSV, formatAuto:
-		fallthrough
-	default:
-		for i, res := range results {
-			title := normalizeTitle(res)
-			url := res.URL
-			if useColor {
-				title = "\x1b[1m" + title + "\x1b[0m"
-				url = "\x1b[36m" + url + "\x1b[0m"
-			}
-			if opts.Number {
-				_, _ = fmt.Fprintf(out, "%d\t%s\t%s\n", i+1, title, url)
-				continue
-			}
-			_, _ = fmt.Fprintf(out, "%s\t%s\n", title, url)
-		}
-		return
-	}
-}
-
-func shouldUseColor(opts model.Options, w io.Writer) bool {
-	if opts.Color == "never" {
-		return false
-	}
-	if opts.Color == "always" {
-		return true
-	}
-	if os.Getenv("NO_COLOR") != "" {
-		return false
-	}
-	termEnv := strings.ToLower(strings.TrimSpace(os.Getenv("TERM")))
-	if termEnv == "dumb" || termEnv == "" {
-		return false
-	}
-	f, ok := w.(*os.File)
-	if !ok {
-		return false
-	}
-	return term.IsTerminal(int(f.Fd()))
 }

--- a/internal/app/format.go
+++ b/internal/app/format.go
@@ -2,17 +2,12 @@ package app
 
 import (
 	"bufio"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/steipete/gifgrep/gifdecode"
-	"github.com/steipete/gifgrep/internal/iterm"
-	"github.com/steipete/gifgrep/internal/kitty"
 	"github.com/steipete/gifgrep/internal/model"
-	"github.com/steipete/gifgrep/internal/sixel"
 	"github.com/steipete/gifgrep/internal/termcaps"
 	"golang.org/x/term"
 )
@@ -29,14 +24,6 @@ const (
 	formatJSON    outputFormat = "json"
 )
 
-type thumbsMode string
-
-const (
-	thumbsAuto   thumbsMode = "auto"
-	thumbsAlways thumbsMode = "always"
-	thumbsNever  thumbsMode = "never"
-)
-
 var isTerminalWriter = func(w io.Writer) bool {
 	f, ok := w.(*os.File)
 	if !ok {
@@ -44,28 +31,6 @@ var isTerminalWriter = func(w io.Writer) bool {
 	}
 	return term.IsTerminal(int(f.Fd()))
 }
-
-var (
-	fetchThumb  = fetchURL
-	decodeThumb = func(data []byte) (*gifdecode.Frames, error) {
-		decodeOpts := gifdecode.DefaultOptions()
-		decodeOpts.MaxFrames = 1
-		return gifdecode.Decode(data, decodeOpts)
-	}
-	sendThumbKitty = func(out *bufio.Writer, id uint32, frame gifdecode.Frame, cols, rows int) {
-		kitty.SendFrame(out, id, frame, cols, rows)
-	}
-	sendThumbIterm = func(out *bufio.Writer, data []byte, cols, rows int) {
-		iterm.SendInlineFile(out, iterm.File{
-			Name:        thumbInlineName(data),
-			Data:        data,
-			WidthCells:  cols,
-			HeightCells: rows,
-			Stretch:     true,
-		})
-	}
-	sendThumbSixel = sixel.SendFrame
-)
 
 func resolveOutputFormat(opts model.Options, stdout io.Writer) outputFormat {
 	if opts.JSON {
@@ -81,97 +46,6 @@ func resolveOutputFormat(opts model.Options, stdout io.Writer) outputFormat {
 	return f
 }
 
-func resolveThumbsMode(opts model.Options) thumbsMode {
-	m := thumbsMode(strings.ToLower(strings.TrimSpace(opts.Thumbs)))
-	if m == "" {
-		return thumbsAuto
-	}
-	return m
-}
-
-func thumbsProtocol(opts model.Options, stdout io.Writer, format outputFormat) termcaps.InlineProtocol {
-	if format != formatPlain {
-		return termcaps.InlineNone
-	}
-	if !isTerminalWriter(stdout) {
-		return termcaps.InlineNone
-	}
-	switch resolveThumbsMode(opts) {
-	case thumbsNever:
-		return termcaps.InlineNone
-	case thumbsAlways:
-		return termcaps.DetectInlineRobust(os.Getenv)
-	case thumbsAuto:
-		return termcaps.DetectInlineRobust(os.Getenv)
-	}
-	return termcaps.DetectInlineRobust(os.Getenv)
-}
-
-func renderPlain(
-	out *bufio.Writer,
-	opts model.Options,
-	useColor bool,
-	thumbs termcaps.InlineProtocol,
-	results []model.Result,
-	termCols int,
-) {
-	nextID := uint32(1)
-	withThumbs := thumbs != termcaps.InlineNone
-	for i, res := range results {
-		title := normalizeTitle(res)
-		url := res.URL
-
-		nPrefix := ""
-		if opts.Number {
-			nPrefix = fmt.Sprintf("%d. ", i+1)
-		}
-
-		if withThumbs && renderThumbBlock(out, thumbs, nextID, res, nPrefix, title, url, useColor, termCols) == nil {
-			nextID++
-			if i < len(results)-1 {
-				if thumbs == termcaps.InlineIterm {
-					_, _ = fmt.Fprint(out, "\r\x1b[K\n")
-				} else {
-					_, _ = fmt.Fprintln(out)
-				}
-			}
-			continue
-		}
-
-		if useColor {
-			title = "\x1b[1m" + nPrefix + title + "\x1b[0m"
-			url = "\x1b[36m" + url + "\x1b[0m"
-		} else {
-			title = nPrefix + title
-		}
-		_, _ = fmt.Fprintln(out, title)
-		_, _ = fmt.Fprintln(out, "  "+url)
-		_, _ = fmt.Fprintln(out)
-	}
-}
-
-func renderThumbBlock(out *bufio.Writer, thumbs termcaps.InlineProtocol, id uint32, res model.Result, nPrefix, title, url string, useColor bool, termCols int) error {
-	data, src, err := fetchThumbForResult(res)
-	if err != nil {
-		return err
-	}
-	cols, rows := thumbBlockSize(thumbs, data, res)
-
-	data, err = prepareThumbData(thumbs, data, src, res)
-	if err != nil {
-		return err
-	}
-	if err := sendThumb(out, thumbs, id, data, cols, rows); err != nil {
-		return err
-	}
-
-	indentCols := thumbIndentCols(thumbs, cols)
-	textWidth := thumbTextWidth(termCols, indentCols)
-	titleLine, urlLines := thumbTextLines(nPrefix, title, url, rows, textWidth)
-	writeThumbTextBlock(out, thumbs, rows, indentCols, titleLine, urlLines, useColor)
-	return nil
-}
-
 func normalizeTitle(res model.Result) string {
 	label := strings.Join(strings.Fields(res.Title), " ")
 	if label == "" {
@@ -183,266 +57,62 @@ func normalizeTitle(res model.Result) string {
 	return label
 }
 
-func clampInt(minVal, maxVal, v int) int {
-	if v < minVal {
-		return minVal
-	}
-	if v > maxVal {
-		return maxVal
-	}
-	return v
-}
-
-func thumbInlineName(data []byte) string {
-	if isGIFData(data) {
-		return "thumb.gif"
-	}
-	if isPNGData(data) {
-		return "thumb.png"
-	}
-	if isJPEGData(data) {
-		return "thumb.jpg"
-	}
-	return "thumb.bin"
-}
-
-func thumbDims(data []byte, res model.Result) (int, int) {
-	if isGIFData(data) {
-		if len(data) < 10 {
-			return 0, 0
-		}
-		w := int(binary.LittleEndian.Uint16(data[6:8]))
-		h := int(binary.LittleEndian.Uint16(data[8:10]))
-		return w, h
-	}
-	if isPNGData(data) {
-		if len(data) < 24 {
-			return 0, 0
-		}
-		w := int(binary.BigEndian.Uint32(data[16:20]))
-		h := int(binary.BigEndian.Uint32(data[20:24]))
-		return w, h
-	}
-	if res.Width > 0 && res.Height > 0 {
-		return res.Width, res.Height
-	}
-	return 0, 0
-}
-
-func isGIFData(data []byte) bool {
-	if len(data) < 6 {
-		return false
-	}
-	hdr := string(data[:6])
-	return hdr == "GIF87a" || hdr == "GIF89a"
-}
-
-func isPNGData(data []byte) bool {
-	if len(data) < 8 {
-		return false
-	}
-	return data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4e && data[3] == 0x47 &&
-		data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a && data[7] == 0x0a
-}
-
-func isJPEGData(data []byte) bool {
-	return len(data) >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff
-}
-
-func isSupportedItermImage(data []byte) bool {
-	return isGIFData(data) || isPNGData(data) || isJPEGData(data)
-}
-
-func fetchThumbForResult(res model.Result) ([]byte, string, error) {
-	src := res.PreviewURL
-	if src == "" {
-		src = res.URL
-	}
-	data, err := fetchThumb(src)
-	if err != nil {
-		return nil, "", err
-	}
-	return data, src, nil
-}
-
-func thumbBlockSize(thumbs termcaps.InlineProtocol, data []byte, res model.Result) (int, int) {
-	cols := 16
-	rows := 8
-	if w, h := thumbDims(data, res); w > 0 && h > 0 {
-		if thumbs != termcaps.InlineIterm {
-			rows = clampInt(3, 10, int(float64(cols)*0.5*float64(h)/float64(w)))
-		}
-	}
-	return cols, rows
-}
-
-func prepareThumbData(thumbs termcaps.InlineProtocol, data []byte, src string, res model.Result) ([]byte, error) {
-	switch thumbs {
-	case termcaps.InlineNone:
-		return nil, fmt.Errorf("inline thumbnails not supported")
-	case termcaps.InlineIterm:
-		if !isSupportedItermImage(data) && src != res.URL && res.URL != "" {
-			if fallback, err := fetchThumb(res.URL); err == nil {
-				data = fallback
+func writeSearchResults(out *bufio.Writer, opts model.Options, useColor bool, thumbs termcaps.InlineProtocol, results []model.Result, termCols int, format outputFormat) {
+	switch format {
+	case formatPlain:
+		renderPlain(out, opts, useColor, thumbs, results, termCols)
+		return
+	case formatURL:
+		for i, res := range results {
+			url := res.URL
+			if opts.Number {
+				_, _ = fmt.Fprintf(out, "%d\t%s\n", i+1, url)
+				continue
 			}
+			_, _ = fmt.Fprintln(out, url)
 		}
-		if len(data) == 0 {
-			return nil, fmt.Errorf("empty image")
+		return
+	case formatMD:
+		for i, res := range results {
+			title := normalizeTitle(res)
+			url := res.URL
+			prefix := "- "
+			if opts.Number {
+				prefix = fmt.Sprintf("%d. ", i+1)
+			}
+			_, _ = fmt.Fprintf(out, "%s[%s](%s)\n", prefix, title, url)
 		}
-		if !isSupportedItermImage(data) {
-			return nil, fmt.Errorf("unsupported image")
+		return
+	case formatComment:
+		for i, res := range results {
+			title := normalizeTitle(res)
+			url := res.URL
+			if opts.Number {
+				_, _ = fmt.Fprintf(out, "%d\t%s  # %s\n", i+1, url, title)
+				continue
+			}
+			_, _ = fmt.Fprintf(out, "%s  # %s\n", url, title)
 		}
-		return data, nil
-	case termcaps.InlineKitty, termcaps.InlineSixel:
-		if len(data) == 0 {
-			return nil, fmt.Errorf("empty image")
-		}
-		return data, nil
-	case termcaps.InlineANSI:
-		return nil, fmt.Errorf("inline thumbnails not supported")
+		return
+	case formatJSON:
+		// handled by caller
+		return
+	case formatTSV, formatAuto:
+		fallthrough
 	default:
-		return nil, fmt.Errorf("inline thumbnails not supported")
-	}
-}
-
-func sendThumb(out *bufio.Writer, thumbs termcaps.InlineProtocol, id uint32, data []byte, cols, rows int) error {
-	switch thumbs {
-	case termcaps.InlineNone:
-		return fmt.Errorf("inline thumbnails not supported")
-	case termcaps.InlineIterm:
-		_, _ = fmt.Fprint(out, "\r")
-		sendThumbIterm(out, data, cols, rows)
-		if rows > 1 {
-			_, _ = fmt.Fprintf(out, "\x1b[%dA", rows-1)
-		}
-		return nil
-	case termcaps.InlineKitty:
-		decoded, err := decodeThumb(data)
-		if err != nil {
-			return err
-		}
-		if decoded == nil || len(decoded.Frames) == 0 {
-			return fmt.Errorf("no frames")
-		}
-		sendThumbKitty(out, id, decoded.Frames[0], cols, rows)
-		return nil
-	case termcaps.InlineSixel:
-		decoded, err := decodeThumb(data)
-		if err != nil {
-			return err
-		}
-		if decoded == nil || len(decoded.Frames) == 0 {
-			return fmt.Errorf("no frames")
-		}
-		saveCursor(out)
-		err = sendThumbSixel(out, decoded.Frames[0], cols, rows)
-		restoreCursor(out)
-		return err
-	case termcaps.InlineANSI:
-		return fmt.Errorf("inline thumbnails not supported")
-	default:
-		return fmt.Errorf("inline thumbnails not supported")
-	}
-}
-
-func saveCursor(out *bufio.Writer) {
-	_, _ = fmt.Fprint(out, "\x1b7")
-}
-
-func restoreCursor(out *bufio.Writer) {
-	_, _ = fmt.Fprint(out, "\x1b8")
-}
-
-func thumbIndentCols(thumbs termcaps.InlineProtocol, cols int) int {
-	if thumbs == termcaps.InlineIterm {
-		return cols
-	}
-	return cols + 2
-}
-
-func thumbTextWidth(termCols int, indentCols int) int {
-	textWidth := termCols - indentCols - 1
-	if termCols <= 0 || textWidth <= 0 {
-		return 0
-	}
-	return textWidth
-}
-
-func thumbTextLines(nPrefix, title, url string, rows int, textWidth int) (string, []string) {
-	titleLine := truncateText(nPrefix+title, textWidth)
-
-	urlLines := []string{url}
-	if textWidth > 0 {
-		urlLines = wrapText(url, textWidth)
-	}
-	if len(urlLines) > rows-1 {
-		urlLines = urlLines[:rows-1]
-		urlLines[len(urlLines)-1] = truncateText(urlLines[len(urlLines)-1]+"…", textWidth)
-	}
-	return titleLine, urlLines
-}
-
-func writeThumbTextBlock(out *bufio.Writer, thumbs termcaps.InlineProtocol, rows, indentCols int, titleLine string, urlLines []string, useColor bool) {
-	for r := 0; r < rows; r++ {
-		line := ""
-		switch r {
-		case 0:
-			line = titleLine
+		for i, res := range results {
+			title := normalizeTitle(res)
+			url := res.URL
 			if useColor {
-				line = "\x1b[1m" + line + "\x1b[0m"
+				title = "\x1b[1m" + title + "\x1b[0m"
+				url = "\x1b[36m" + url + "\x1b[0m"
 			}
-		default:
-			if i := r - 1; i >= 0 && i < len(urlLines) {
-				line = urlLines[i]
-				if useColor {
-					line = "\x1b[36m" + line + "\x1b[0m"
-				}
+			if opts.Number {
+				_, _ = fmt.Fprintf(out, "%d\t%s\t%s\n", i+1, title, url)
+				continue
 			}
+			_, _ = fmt.Fprintf(out, "%s\t%s\n", title, url)
 		}
-
-		if thumbs == termcaps.InlineIterm {
-			col := indentCols + 1
-			if col < 1 {
-				col = 1
-			}
-			_, _ = fmt.Fprintf(out, "\x1b[%dG", col)
-			_, _ = fmt.Fprint(out, line)
-			_, _ = fmt.Fprint(out, "\x1b[K\n")
-			continue
-		}
-
-		_, _ = fmt.Fprint(out, strings.Repeat(" ", indentCols))
-		_, _ = fmt.Fprintln(out, line)
+		return
 	}
-}
-
-func truncateText(s string, width int) string {
-	if width <= 0 {
-		return s
-	}
-	r := []rune(s)
-	if len(r) <= width {
-		return s
-	}
-	if width <= 1 {
-		return "…"
-	}
-	return string(r[:width-1]) + "…"
-}
-
-func wrapText(s string, width int) []string {
-	if width <= 0 || s == "" {
-		return []string{s}
-	}
-	var out []string
-	r := []rune(s)
-	for len(r) > 0 {
-		n := width
-		if n > len(r) {
-			n = len(r)
-		}
-		out = append(out, string(r[:n]))
-		r = r[n:]
-	}
-	return out
 }

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -1,0 +1,117 @@
+package app
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/steipete/gifgrep/internal/download"
+	"github.com/steipete/gifgrep/internal/model"
+	"github.com/steipete/gifgrep/internal/reveal"
+	"github.com/steipete/gifgrep/internal/search"
+	"github.com/steipete/gifgrep/internal/termcaps"
+	"golang.org/x/term"
+)
+
+func runSearch(stdout io.Writer, stderr io.Writer, opts model.Options, query string) error {
+	if strings.TrimSpace(query) == "" {
+		return errors.New("missing query")
+	}
+	logSearchConfig(stderr, opts)
+
+	results, err := search.Search(query, opts)
+	if err != nil {
+		return err
+	}
+
+	if err := downloadSearchResults(results, opts, stderr); err != nil {
+		return err
+	}
+
+	format := resolveOutputFormat(opts, stdout)
+	out := bufio.NewWriter(stdout)
+	defer func() { _ = out.Flush() }()
+	if format == formatJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
+	}
+
+	useColor := shouldUseColor(opts, stdout)
+	thumbs := thumbsProtocol(opts, stdout, format)
+	termCols := termColumns(stdout, thumbs)
+
+	writeSearchResults(out, opts, useColor, thumbs, results, termCols, format)
+	return nil
+}
+
+func logSearchConfig(stderr io.Writer, opts model.Options) {
+	if opts.Verbose > 0 && !opts.Quiet {
+		_, _ = fmt.Fprintf(stderr, "source=%s max=%d\n", search.ResolveSource(opts.Source), opts.Limit)
+	}
+}
+
+func downloadSearchResults(results []model.Result, opts model.Options, stderr io.Writer) error {
+	if !opts.Download {
+		return nil
+	}
+
+	var lastSaved string
+	for _, res := range results {
+		if res.URL == "" {
+			continue
+		}
+		savedPath, err := download.ToDownloads(res, opts.Cache)
+		if err != nil {
+			return err
+		}
+		lastSaved = savedPath
+		if opts.Verbose > 0 && !opts.Quiet {
+			_, _ = fmt.Fprintf(stderr, "saved %s\n", savedPath)
+		}
+	}
+	if opts.Reveal && lastSaved != "" {
+		return reveal.Reveal(lastSaved)
+	}
+	return nil
+}
+
+func termColumns(w io.Writer, thumbs termcaps.InlineProtocol) int {
+	if thumbs == termcaps.InlineNone {
+		return 0
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0
+	}
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols <= 0 {
+		return 0
+	}
+	return cols
+}
+
+func shouldUseColor(opts model.Options, w io.Writer) bool {
+	if opts.Color == "never" {
+		return false
+	}
+	if opts.Color == "always" {
+		return true
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	termEnv := strings.ToLower(strings.TrimSpace(os.Getenv("TERM")))
+	if termEnv == "dumb" || termEnv == "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}

--- a/internal/app/thumbs.go
+++ b/internal/app/thumbs.go
@@ -1,0 +1,394 @@
+package app
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/steipete/gifgrep/gifdecode"
+	"github.com/steipete/gifgrep/internal/iterm"
+	"github.com/steipete/gifgrep/internal/kitty"
+	"github.com/steipete/gifgrep/internal/model"
+	"github.com/steipete/gifgrep/internal/sixel"
+	"github.com/steipete/gifgrep/internal/termcaps"
+)
+
+type thumbsMode string
+
+const (
+	thumbsAuto   thumbsMode = "auto"
+	thumbsAlways thumbsMode = "always"
+	thumbsNever  thumbsMode = "never"
+)
+
+var (
+	fetchThumb  = fetchURL
+	decodeThumb = func(data []byte) (*gifdecode.Frames, error) {
+		decodeOpts := gifdecode.DefaultOptions()
+		decodeOpts.MaxFrames = 1
+		return gifdecode.Decode(data, decodeOpts)
+	}
+	sendThumbKitty = func(out *bufio.Writer, id uint32, frame gifdecode.Frame, cols, rows int) {
+		kitty.SendFrame(out, id, frame, cols, rows)
+	}
+	sendThumbIterm = func(out *bufio.Writer, data []byte, cols, rows int) {
+		iterm.SendInlineFile(out, iterm.File{
+			Name:        thumbInlineName(data),
+			Data:        data,
+			WidthCells:  cols,
+			HeightCells: rows,
+			Stretch:     true,
+		})
+	}
+	sendThumbSixel = sixel.SendFrame
+)
+
+func resolveThumbsMode(opts model.Options) thumbsMode {
+	m := thumbsMode(strings.ToLower(strings.TrimSpace(opts.Thumbs)))
+	if m == "" {
+		return thumbsAuto
+	}
+	return m
+}
+
+func thumbsProtocol(opts model.Options, stdout io.Writer, format outputFormat) termcaps.InlineProtocol {
+	if format != formatPlain {
+		return termcaps.InlineNone
+	}
+	if !isTerminalWriter(stdout) {
+		return termcaps.InlineNone
+	}
+	switch resolveThumbsMode(opts) {
+	case thumbsNever:
+		return termcaps.InlineNone
+	case thumbsAuto, thumbsAlways:
+		return termcaps.DetectInlineRobust(os.Getenv)
+	}
+	return termcaps.DetectInlineRobust(os.Getenv)
+}
+
+func renderPlain(
+	out *bufio.Writer,
+	opts model.Options,
+	useColor bool,
+	thumbs termcaps.InlineProtocol,
+	results []model.Result,
+	termCols int,
+) {
+	nextID := uint32(1)
+	withThumbs := thumbs != termcaps.InlineNone
+	for i, res := range results {
+		title := normalizeTitle(res)
+		url := res.URL
+
+		nPrefix := ""
+		if opts.Number {
+			nPrefix = fmt.Sprintf("%d. ", i+1)
+		}
+
+		if withThumbs && renderThumbBlock(out, thumbs, nextID, res, nPrefix, title, url, useColor, termCols) == nil {
+			nextID++
+			if i < len(results)-1 {
+				if thumbs == termcaps.InlineIterm {
+					_, _ = fmt.Fprint(out, "\r\x1b[K\n")
+				} else {
+					_, _ = fmt.Fprintln(out)
+				}
+			}
+			continue
+		}
+
+		if useColor {
+			title = "\x1b[1m" + nPrefix + title + "\x1b[0m"
+			url = "\x1b[36m" + url + "\x1b[0m"
+		} else {
+			title = nPrefix + title
+		}
+		_, _ = fmt.Fprintln(out, title)
+		_, _ = fmt.Fprintln(out, "  "+url)
+		_, _ = fmt.Fprintln(out)
+	}
+}
+
+func renderThumbBlock(out *bufio.Writer, thumbs termcaps.InlineProtocol, id uint32, res model.Result, nPrefix, title, url string, useColor bool, termCols int) error {
+	data, src, err := fetchThumbForResult(res)
+	if err != nil {
+		return err
+	}
+	cols, rows := thumbBlockSize(thumbs, data, res)
+
+	data, err = prepareThumbData(thumbs, data, src, res)
+	if err != nil {
+		return err
+	}
+	if err := sendThumb(out, thumbs, id, data, cols, rows); err != nil {
+		return err
+	}
+
+	indentCols := thumbIndentCols(thumbs, cols)
+	textWidth := thumbTextWidth(termCols, indentCols)
+	titleLine, urlLines := thumbTextLines(nPrefix, title, url, rows, textWidth)
+	writeThumbTextBlock(out, thumbs, rows, indentCols, titleLine, urlLines, useColor)
+	return nil
+}
+
+func clampInt(minVal, maxVal, v int) int {
+	if v < minVal {
+		return minVal
+	}
+	if v > maxVal {
+		return maxVal
+	}
+	return v
+}
+
+func thumbInlineName(data []byte) string {
+	if isGIFData(data) {
+		return "thumb.gif"
+	}
+	if isPNGData(data) {
+		return "thumb.png"
+	}
+	if isJPEGData(data) {
+		return "thumb.jpg"
+	}
+	return "thumb.bin"
+}
+
+func thumbDims(data []byte, res model.Result) (int, int) {
+	if isGIFData(data) {
+		if len(data) < 10 {
+			return 0, 0
+		}
+		w := int(binary.LittleEndian.Uint16(data[6:8]))
+		h := int(binary.LittleEndian.Uint16(data[8:10]))
+		return w, h
+	}
+	if isPNGData(data) {
+		if len(data) < 24 {
+			return 0, 0
+		}
+		w := int(binary.BigEndian.Uint32(data[16:20]))
+		h := int(binary.BigEndian.Uint32(data[20:24]))
+		return w, h
+	}
+	if res.Width > 0 && res.Height > 0 {
+		return res.Width, res.Height
+	}
+	return 0, 0
+}
+
+func isGIFData(data []byte) bool {
+	if len(data) < 6 {
+		return false
+	}
+	hdr := string(data[:6])
+	return hdr == "GIF87a" || hdr == "GIF89a"
+}
+
+func isPNGData(data []byte) bool {
+	if len(data) < 8 {
+		return false
+	}
+	return data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4e && data[3] == 0x47 &&
+		data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a && data[7] == 0x0a
+}
+
+func isJPEGData(data []byte) bool {
+	return len(data) >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff
+}
+
+func isSupportedItermImage(data []byte) bool {
+	return isGIFData(data) || isPNGData(data) || isJPEGData(data)
+}
+
+func fetchThumbForResult(res model.Result) ([]byte, string, error) {
+	src := res.PreviewURL
+	if src == "" {
+		src = res.URL
+	}
+	data, err := fetchThumb(src)
+	if err != nil {
+		return nil, "", err
+	}
+	return data, src, nil
+}
+
+func thumbBlockSize(thumbs termcaps.InlineProtocol, data []byte, res model.Result) (int, int) {
+	cols := 16
+	rows := 8
+	if w, h := thumbDims(data, res); w > 0 && h > 0 {
+		if thumbs != termcaps.InlineIterm {
+			rows = clampInt(3, 10, int(float64(cols)*0.5*float64(h)/float64(w)))
+		}
+	}
+	return cols, rows
+}
+
+func prepareThumbData(thumbs termcaps.InlineProtocol, data []byte, src string, res model.Result) ([]byte, error) {
+	switch thumbs {
+	case termcaps.InlineNone:
+		return nil, fmt.Errorf("inline thumbnails not supported")
+	case termcaps.InlineIterm:
+		if !isSupportedItermImage(data) && src != res.URL && res.URL != "" {
+			if fallback, err := fetchThumb(res.URL); err == nil {
+				data = fallback
+			}
+		}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("empty image")
+		}
+		if !isSupportedItermImage(data) {
+			return nil, fmt.Errorf("unsupported image")
+		}
+		return data, nil
+	case termcaps.InlineKitty, termcaps.InlineSixel:
+		if len(data) == 0 {
+			return nil, fmt.Errorf("empty image")
+		}
+		return data, nil
+	case termcaps.InlineANSI:
+		return nil, fmt.Errorf("inline thumbnails not supported")
+	default:
+		return nil, fmt.Errorf("inline thumbnails not supported")
+	}
+}
+
+func sendThumb(out *bufio.Writer, thumbs termcaps.InlineProtocol, id uint32, data []byte, cols, rows int) error {
+	switch thumbs {
+	case termcaps.InlineNone:
+		return fmt.Errorf("inline thumbnails not supported")
+	case termcaps.InlineIterm:
+		_, _ = fmt.Fprint(out, "\r")
+		sendThumbIterm(out, data, cols, rows)
+		if rows > 1 {
+			_, _ = fmt.Fprintf(out, "\x1b[%dA", rows-1)
+		}
+		return nil
+	case termcaps.InlineKitty, termcaps.InlineSixel:
+		decoded, err := decodeThumb(data)
+		if err != nil {
+			return err
+		}
+		if decoded == nil || len(decoded.Frames) == 0 {
+			return fmt.Errorf("no frames")
+		}
+		if thumbs == termcaps.InlineKitty {
+			sendThumbKitty(out, id, decoded.Frames[0], cols, rows)
+			return nil
+		}
+		saveCursor(out)
+		err = sendThumbSixel(out, decoded.Frames[0], cols, rows)
+		restoreCursor(out)
+		return err
+	case termcaps.InlineANSI:
+		return fmt.Errorf("inline thumbnails not supported")
+	default:
+		return fmt.Errorf("inline thumbnails not supported")
+	}
+}
+
+func saveCursor(out *bufio.Writer) {
+	_, _ = fmt.Fprint(out, "\x1b7")
+}
+
+func restoreCursor(out *bufio.Writer) {
+	_, _ = fmt.Fprint(out, "\x1b8")
+}
+
+func thumbIndentCols(thumbs termcaps.InlineProtocol, cols int) int {
+	if thumbs == termcaps.InlineIterm {
+		return cols
+	}
+	return cols + 2
+}
+
+func thumbTextWidth(termCols int, indentCols int) int {
+	textWidth := termCols - indentCols - 1
+	if termCols <= 0 || textWidth <= 0 {
+		return 0
+	}
+	return textWidth
+}
+
+func thumbTextLines(nPrefix, title, url string, rows int, textWidth int) (string, []string) {
+	titleLine := truncateText(nPrefix+title, textWidth)
+
+	urlLines := []string{url}
+	if textWidth > 0 {
+		urlLines = wrapText(url, textWidth)
+	}
+	if len(urlLines) > rows-1 {
+		urlLines = urlLines[:rows-1]
+		urlLines[len(urlLines)-1] = truncateText(urlLines[len(urlLines)-1]+"…", textWidth)
+	}
+	return titleLine, urlLines
+}
+
+func writeThumbTextBlock(out *bufio.Writer, thumbs termcaps.InlineProtocol, rows, indentCols int, titleLine string, urlLines []string, useColor bool) {
+	for r := 0; r < rows; r++ {
+		line := ""
+		switch r {
+		case 0:
+			line = titleLine
+			if useColor {
+				line = "\x1b[1m" + line + "\x1b[0m"
+			}
+		default:
+			if i := r - 1; i >= 0 && i < len(urlLines) {
+				line = urlLines[i]
+				if useColor {
+					line = "\x1b[36m" + line + "\x1b[0m"
+				}
+			}
+		}
+
+		if thumbs == termcaps.InlineIterm {
+			col := indentCols + 1
+			if col < 1 {
+				col = 1
+			}
+			_, _ = fmt.Fprintf(out, "\x1b[%dG", col)
+			_, _ = fmt.Fprint(out, line)
+			_, _ = fmt.Fprint(out, "\x1b[K\n")
+			continue
+		}
+
+		_, _ = fmt.Fprint(out, strings.Repeat(" ", indentCols))
+		_, _ = fmt.Fprintln(out, line)
+	}
+}
+
+func truncateText(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= width {
+		return s
+	}
+	if width <= 1 {
+		return "…"
+	}
+	return string(r[:width-1]) + "…"
+}
+
+func wrapText(s string, width int) []string {
+	if width <= 0 || s == "" {
+		return []string{s}
+	}
+	var out []string
+	r := []rune(s)
+	for len(r) > 0 {
+		n := width
+		if n > len(r) {
+			n = len(r)
+		}
+		out = append(out, string(r[:n]))
+		r = r[n:]
+	}
+	return out
+}

--- a/internal/download/cache.go
+++ b/internal/download/cache.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -109,7 +109,7 @@ func pruneDownloadCache(dir string, opts model.CacheOptions) {
 	if opts.MaxBytes == 0 {
 		return
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].ModTime().Before(files[j].ModTime()) })
+	slices.SortFunc(files, func(a, b os.FileInfo) int { return a.ModTime().Compare(b.ModTime()) })
 	for _, info := range files {
 		if total <= opts.MaxBytes {
 			break

--- a/internal/search/giphy.go
+++ b/internal/search/giphy.go
@@ -1,14 +1,10 @@
 package search
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/steipete/gifgrep/internal/model"
 )
@@ -24,14 +20,10 @@ type giphySearchResponse struct {
 				Height string `json:"height"`
 			} `json:"original"`
 			FixedWidthSmall struct {
-				URL    string `json:"url"`
-				Width  string `json:"width"`
-				Height string `json:"height"`
+				URL string `json:"url"`
 			} `json:"fixed_width_small"`
 			PreviewGIF struct {
-				URL    string `json:"url"`
-				Width  string `json:"width"`
-				Height string `json:"height"`
+				URL string `json:"url"`
 			} `json:"preview_gif"`
 		} `json:"images"`
 	} `json:"data"`
@@ -51,28 +43,11 @@ func fetchGiphyV1(query string, opts model.Options) ([]model.Result, error) {
 	params := url.Values{}
 	params.Set("q", query)
 	params.Set("api_key", apiKey)
-	params.Set("limit", fmt.Sprintf("%d", limit))
+	params.Set("limit", strconv.Itoa(limit))
 	params.Set("rating", "g")
 
-	reqURL := "https://api.giphy.com/v1/gifs/search?" + params.Encode()
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", "gifgrep")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("http %d", resp.StatusCode)
-	}
-
 	var parsed giphySearchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := fetchSearchJSON("https://api.giphy.com/v1/gifs/search", params, &parsed); err != nil {
 		return nil, err
 	}
 

--- a/internal/search/http.go
+++ b/internal/search/http.go
@@ -1,0 +1,27 @@
+package search
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+func fetchSearchJSON(endpoint string, params url.Values, dest any) error {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, endpoint+"?"+params.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "gifgrep")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
+}

--- a/internal/search/klipy.go
+++ b/internal/search/klipy.go
@@ -1,0 +1,100 @@
+package search
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/steipete/gifgrep/internal/model"
+)
+
+type klipyV2Response struct {
+	Results []klipyV2Result `json:"results"`
+}
+
+type klipyV2Result struct {
+	ID                 string             `json:"id"`
+	Title              string             `json:"title"`
+	ContentDescription string             `json:"content_description"`
+	Tags               []string           `json:"tags"`
+	MediaFormats       map[string]mediaV2 `json:"media_formats"`
+}
+
+type mediaV2 struct {
+	URL  string `json:"url"`
+	Dims []int  `json:"dims"`
+}
+
+func fetchKlipyV2(query string, opts model.Options) ([]model.Result, error) {
+	apiKey := os.Getenv("KLIPY_API_KEY")
+	if apiKey == "" {
+		return nil, errors.New("missing KLIPY_API_KEY")
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+
+	params := url.Values{}
+	params.Set("q", query)
+	params.Set("key", apiKey)
+	params.Set("limit", strconv.Itoa(limit))
+	params.Set("contentfilter", "low")
+	params.Set("media_filter", "gif,tinygif,mediumgif,nanogif,preview")
+
+	var parsed klipyV2Response
+	if err := fetchSearchJSON("https://api.klipy.com/v2/search", params, &parsed); err != nil {
+		return nil, err
+	}
+
+	out := make([]model.Result, 0, len(parsed.Results))
+	for i := range parsed.Results {
+		r := &parsed.Results[i]
+		title := r.Title
+		if title == "" {
+			title = r.ContentDescription
+		}
+		if title == "" {
+			title = r.ID
+		}
+
+		gifMedia, ok := mediaFormat(r.MediaFormats, "gif", "mediumgif", "tinygif", "nanogif", "preview")
+		if !ok || gifMedia.URL == "" {
+			continue
+		}
+		previewMedia, ok := mediaFormat(r.MediaFormats, "tinygif", "nanogif", "preview", "mediumgif", "gif")
+		if !ok || previewMedia.URL == "" {
+			previewMedia = gifMedia
+		}
+		width, height := mediaDims(gifMedia)
+
+		out = append(out, model.Result{
+			ID:         r.ID,
+			Title:      title,
+			URL:        gifMedia.URL,
+			PreviewURL: previewMedia.URL,
+			Tags:       r.Tags,
+			Width:      width,
+			Height:     height,
+		})
+	}
+	return out, nil
+}
+
+func mediaFormat(formats map[string]mediaV2, names ...string) (mediaV2, bool) {
+	for _, name := range names {
+		media, ok := formats[name]
+		if ok && media.URL != "" {
+			return media, true
+		}
+	}
+	return mediaV2{}, false
+}
+
+func mediaDims(media mediaV2) (int, int) {
+	if len(media.Dims) != 2 {
+		return 0, 0
+	}
+	return media.Dims[0], media.Dims[1]
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,34 +1,12 @@
 package search
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/steipete/gifgrep/internal/model"
 )
-
-type klipyV2Response struct {
-	Results []klipyV2Result `json:"results"`
-}
-
-type klipyV2Result struct {
-	ID                 string             `json:"id"`
-	Title              string             `json:"title"`
-	ContentDescription string             `json:"content_description"`
-	Tags               []string           `json:"tags"`
-	MediaFormats       map[string]mediaV2 `json:"media_formats"`
-}
-
-type mediaV2 struct {
-	URL  string `json:"url"`
-	Dims []int  `json:"dims"`
-}
 
 func Search(query string, opts model.Options) ([]model.Result, error) {
 	source := ResolveSource(opts.Source)
@@ -53,96 +31,4 @@ func Search(query string, opts model.Options) ([]model.Result, error) {
 func isAutoSource(source string) bool {
 	source = strings.ToLower(strings.TrimSpace(source))
 	return source == "" || source == "auto"
-}
-
-func fetchKlipyV2(query string, opts model.Options) ([]model.Result, error) {
-	apiKey := os.Getenv("KLIPY_API_KEY")
-	if apiKey == "" {
-		return nil, errors.New("missing KLIPY_API_KEY")
-	}
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = 20
-	}
-
-	params := url.Values{}
-	params.Set("q", query)
-	params.Set("key", apiKey)
-	params.Set("limit", fmt.Sprintf("%d", limit))
-	params.Set("contentfilter", "low")
-	params.Set("media_filter", "gif,tinygif,mediumgif,nanogif,preview")
-
-	reqURL := "https://api.klipy.com/v2/search?" + params.Encode()
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", "gifgrep")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("http %d", resp.StatusCode)
-	}
-
-	var parsed klipyV2Response
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, err
-	}
-
-	out := make([]model.Result, 0, len(parsed.Results))
-	for i := range parsed.Results {
-		r := &parsed.Results[i]
-		title := r.Title
-		if title == "" {
-			title = r.ContentDescription
-		}
-		if title == "" {
-			title = r.ID
-		}
-
-		gifMedia, ok := mediaFormat(r.MediaFormats, "gif", "mediumgif", "tinygif", "nanogif", "preview")
-		if !ok || gifMedia.URL == "" {
-			continue
-		}
-		previewMedia, ok := mediaFormat(r.MediaFormats, "tinygif", "nanogif", "preview", "mediumgif", "gif")
-		if !ok || previewMedia.URL == "" {
-			previewMedia = gifMedia
-		}
-		width, height := mediaDims(gifMedia)
-
-		out = append(out, model.Result{
-			ID:         r.ID,
-			Title:      title,
-			URL:        gifMedia.URL,
-			PreviewURL: previewMedia.URL,
-			Tags:       r.Tags,
-			Width:      width,
-			Height:     height,
-		})
-	}
-	return out, nil
-}
-
-func mediaFormat(formats map[string]mediaV2, names ...string) (mediaV2, bool) {
-	for _, name := range names {
-		media, ok := formats[name]
-		if ok && media.URL != "" {
-			return media, true
-		}
-	}
-	return mediaV2{}, false
-}
-
-func mediaDims(media mediaV2) (int, int) {
-	if len(media.Dims) != 2 {
-		return 0, 0
-	}
-	return media.Dims[0], media.Dims[1]
 }


### PR DESCRIPTION
Separate CLI command definitions, search execution, text formats and thumbnails; give KLIPY its own provider module and share the two providers' HTTP/JSON request lifecycle. This removes duplicate request and first-frame decode paths while preserving flags, provider fallback, timeout, User-Agent and output.

Use standard slice sorting, byte cloning and benchmark loops supported by the existing Go 1.25 floor. Remove four redundant gocritic settings that are enabled by default.

Validation: full Go suite, gofumpt, `golangci-lint run` (0 issues and no redundant-setting warnings), isolated Codex autoreview through P2 (scoped-clean). Built the CLI and ran still/sheet extraction against the repository fixture (contact sheet decoded as 250×82 PNG). A compiled CLI fixture launcher redirects only HTTP transport to a loopback server: GIPHY, KLIPY, auto and the tenor alias each returned successful results in all six output formats (24 searches, JSON parsed and dimensions checked). No production credentials or public CLI hooks were added.
