### PR TITLE
ci: update dependencies and verify supported Go platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          go-version: 1.27.1
 
       - name: Install tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -32,4 +40,48 @@ jobs:
         run: golangci-lint run
 
       - name: Test
-        run: go test ./... -cover
+        run: go test -race ./... -cover
+
+      - name: CLI smoke
+        run: |
+          go build -o "$RUNNER_TEMP/gifgrep" ./cmd/gifgrep
+          "$RUNNER_TEMP/gifgrep" --help
+          "$RUNNER_TEMP/gifgrep" still gifdecode/testdata/animexample2.gif --at 0 -o "$RUNNER_TEMP/still.png"
+          "$RUNNER_TEMP/gifgrep" sheet gifdecode/testdata/animexample2.gif --frames 3 -o "$RUNNER_TEMP/sheet.png"
+
+  compatibility:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            go: 1.26.8
+          - os: macos-latest
+            go: 1.27.1
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go test ./...
+      - name: CLI smoke
+        run: |
+          go build -o "$RUNNER_TEMP/gifgrep" ./cmd/gifgrep
+          "$RUNNER_TEMP/gifgrep" --version
+          "$RUNNER_TEMP/gifgrep" still gifdecode/testdata/animexample2.gif --at 0 -o "$RUNNER_TEMP/still.png"
+
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run docs-site
+      - name: Check generated documentation
+        run: git diff --exit-code -- docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Compatibility: source builds now require Go 1.26, the oldest maintained Go line, for the updated terminal/system dependencies; prebuilt binary usage is unchanged.
+- Dependencies: update x/term to 0.46.0, x/sys to 0.48.0, and Playwright to 1.63.0; test Linux/macOS, the minimum Go line, race detection, built CLI commands, and generated docs in CI.
 - Docs: correct search formats, thumbnail flags, optional JSON fields, and terminal preview behavior; keep the generated site in sync.
 
 ## 0.4.1 - 2026-09-11

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/steipete/gifgrep/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/steipete/gifgrep/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/steipete/gifgrep?style=flat-square)](https://github.com/steipete/gifgrep/releases/latest)
-[![Go](https://img.shields.io/badge/Go-1.25%2B-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/github/license/steipete/gifgrep?style=flat-square)](LICENSE)
 [![Homebrew](https://img.shields.io/badge/Homebrew-steipete%2Ftap-FBB040?style=flat-square&logo=homebrew&logoColor=black)](https://github.com/steipete/homebrew-tap/blob/main/Formula/gifgrep.rb)
 [![Docs](https://img.shields.io/badge/docs-gifgrep.com-6f42c1?style=flat-square)](https://gifgrep.com)
@@ -32,7 +32,7 @@ Homebrew is the shortest path on macOS and Linux:
 brew install steipete/tap/gifgrep
 ```
 
-With Go 1.25 or newer:
+With Go 1.26 or newer:
 
 ```bash
 go install github.com/steipete/gifgrep/cmd/gifgrep@latest

--- a/docs/development.html
+++ b/docs/development.html
@@ -268,13 +268,14 @@ body:not(.home) .doc>h1:first-child{display:none}
       <div class="doc-grid">
         <article class="doc"><h1 id="development">Development</h1>
 <h2 id="go-workflow"><a class="anchor" href="#go-workflow" aria-label="Anchor link">#</a>Go workflow</h2>
+<p>Source builds require Go 1.26 or newer; <code>go.mod</code> pins the default development toolchain. CI tests the minimum supported Go line on Linux and the pinned toolchain on Linux/macOS, with race detection on Linux.</p>
 <p>Run the test suite and static checks before submitting a change:</p>
 <pre><code class="language-bash"><span class="hl-cmd">make</span> test
 <span class="hl-cmd">make</span> check
 <span class="hl-cmd">make</span> <span class="hl-cmd">gifgrep</span> -- <span class="hl-f">--help</span></code></pre>
 <h2 id="documentation-site"><a class="anchor" href="#documentation-site" aria-label="Anchor link">#</a>Documentation site</h2>
-<p>The Markdown sources and generated GitHub Pages site live in <code>docs/</code>.</p>
-<pre><code class="language-bash"><span class="hl-cmd">npm</span> install
+<p>The Markdown sources and generated GitHub Pages site live in <code>docs/</code>. Use Node.js 24 LTS for documentation and snapshot tooling.</p>
+<pre><code class="language-bash"><span class="hl-cmd">npm</span> ci
 <span class="hl-cmd">make</span> docs-site</code></pre>
 <p>The builder generates HTML and <code>llms.txt</code> together and validates local links. Commit the regenerated files with Markdown changes. The Markdown renderer, syntax highlighter, and shared HTML escaping live in separate <code>scripts/docs-*.mjs</code> modules.</p>
 <h2 id="ghostty-web-snapshot"><a class="anchor" href="#ghostty-web-snapshot" aria-label="Anchor link">#</a>Ghostty web snapshot</h2>

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,8 @@ description: "Build gifgrep, regenerate its docs, and capture the Ghostty web sn
 
 ## Go workflow
 
+Source builds require Go 1.26 or newer; `go.mod` pins the default development toolchain. CI tests the minimum supported Go line on Linux and the pinned toolchain on Linux/macOS, with race detection on Linux.
+
 Run the test suite and static checks before submitting a change:
 
 ```bash
@@ -17,10 +19,10 @@ make gifgrep -- --help
 
 ## Documentation site
 
-The Markdown sources and generated GitHub Pages site live in `docs/`.
+The Markdown sources and generated GitHub Pages site live in `docs/`. Use Node.js 24 LTS for documentation and snapshot tooling.
 
 ```bash
-npm install
+npm ci
 make docs-site
 ```
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -274,7 +274,7 @@ body:not(.home) .doc>h1:first-child{display:none}
 <p>This is the recommended path — <code>brew upgrade</code> will pick up new releases.</p>
 <h2 id="go-install"><a class="anchor" href="#go-install" aria-label="Anchor link">#</a>go install</h2>
 <pre><code class="language-bash"><span class="hl-cmd">go</span> install github.com/steipete/<span class="hl-cmd">gifgrep</span>/cmd/<span class="hl-cmd">gifgrep</span>@latest</code></pre>
-<p>You&#39;ll need Go ≥ 1.25 and <code>$(go env GOPATH)/bin</code> on your <code>PATH</code>.</p>
+<p>You&#39;ll need Go ≥ 1.26 and <code>$(go env GOPATH)/bin</code> on your <code>PATH</code>.</p>
 <h2 id="pre-built-binaries"><a class="anchor" href="#pre-built-binaries" aria-label="Anchor link">#</a>Pre-built binaries</h2>
 <p>Download for your platform from the <a href="https://github.com/steipete/gifgrep/releases/latest">latest release</a>:</p>
 <ul>

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ This is the recommended path — `brew upgrade` will pick up new releases.
 go install github.com/steipete/gifgrep/cmd/gifgrep@latest
 ```
 
-You'll need Go ≥ 1.25 and `$(go env GOPATH)/bin` on your `PATH`.
+You'll need Go ≥ 1.26 and `$(go env GOPATH)/bin` on your `PATH`.
 
 ## Pre-built binaries
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/gifgrep
 
-go 1.25.0
+go 1.26.0
 
 toolchain go1.27.1
 
@@ -8,11 +8,11 @@ require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/mattn/go-runewidth v0.0.30
 	github.com/mattn/go-sixel v0.0.12
-	golang.org/x/term v0.45.0
+	golang.org/x/term v0.46.0
 )
 
 require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/soniakeys/quant v1.0.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.48.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,7 @@ github.com/mattn/go-sixel v0.0.12 h1:pQadX/oJ4fhSi6RnFHggWELW1TvADrQP9b+Kdx1wNzs
 github.com/mattn/go-sixel v0.0.12/go.mod h1:Z5QJ/vRbnpAl4CTN0NZ0mzURdMccsG7rpGZ5eJfZ6ys=
 github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y=
 github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=
-golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
-golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
+golang.org/x/sys v0.48.0 h1:bbX/i/6MgT9BVLM9RT1thmxL04yeTAhbEz4SyadbXoo=
+golang.org/x/sys v0.48.0/go.mod h1:hNLxWAXmnKAxqDtdwIYC4bM9oQPEecfsnNMuSxOs3og=
+golang.org/x/term v0.46.0 h1:3+OXuTbaKDgwk8jTi3aSLHRlmWqHEUDUtxnbFigO4YE=
+golang.org/x/term v0.46.0/go.mod h1:+K02xbkittuwc0Am4abfA3Fc+XRGXkvBXNO88NCXPoc=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,47 +8,29 @@
       "name": "gifgrep",
       "version": "0.4.1",
       "devDependencies": {
-        "playwright": "^1.62.1"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "playwright": "^1.63.0"
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.1"
+        "playwright-core": "1.63.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "check": "go vet ./..."
   },
   "devDependencies": {
-    "playwright": "^1.62.1"
+    "playwright": "^1.63.0"
   }
 }


### PR DESCRIPTION
Update x/term to 0.46.0 (September 8), x/sys to 0.48.0 (August 31), and Playwright to 1.63.0 (September 4); all are older than 48 hours. The terminal/system modules require Go 1.26, so source builds now require that maintained Go line, with a Compatibility changelog entry and updated installation docs. The default toolchain remains 1.27.1. No application version change or release.

Keep current formatter/linter pins and the repository's floating action-major convention: audited action/tool releases are already current. Add Node 24 LTS, Linux race tests, Go 1.26.8 minimum-line tests, macOS tests on the pinned toolchain, built-CLI smoke commands, generated-doc verification and cancellation of superseded CI runs.

Validation: `go test -race ./...`, `GOTOOLCHAIN=go1.26.8 go test ./...`, lint (0 issues), vet, gofumpt, npm ci (0 vulnerabilities), Playwright CLI version, documentation regeneration/link validation, isolated Codex review through P2 (scoped-clean). Built CLI binaries with both Go versions and extracted repository GIF frames; decoded PNG dimensions/pixels match exactly (82×82), although compressed PNG bytes differ between Go releases. Default-toolchain still and contact-sheet commands both succeeded.

Go support policy: https://go.dev/doc/devel/release#policy

The first CI run exposed setup-go selecting the minimum go directive rather than the toolchain directive under GOTOOLCHAIN=local. Its minimum-Go, macOS and docs jobs passed, but lint rejected a Go 1.26-built linter targeting 1.27.1. The build job now explicitly pins 1.27.1; the complete staged candidate passed isolated review again. All checks are rerun on the corrected head before merge.
