### PR TITLE
fix(extract): honor complete animations and validate size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Extraction: use the complete GIF, include every frame when requested, reject invalid timestamps, and validate image/sheet dimensions before allocation (40-million-pixel sheet limit).
 - Compatibility: source builds now require Go 1.26, the oldest maintained Go line, for the updated terminal/system dependencies; prebuilt binary usage is unchanged.
 - Dependencies: update x/term to 0.46.0, x/sys to 0.48.0, and Playwright to 1.63.0; test Linux/macOS, the minimum Go line, race detection, built CLI commands, and generated docs in CI.
 - Docs: correct search formats, thumbnail flags, optional JSON fields, and terminal preview behavior; keep the generated site in sync.

--- a/docs/sheet.html
+++ b/docs/sheet.html
@@ -283,6 +283,7 @@ body:not(.home) .doc>h1:first-child{display:none}
 <h2 id="how-sampling-works"><a class="anchor" href="#how-sampling-works" aria-label="Anchor link">#</a>How sampling works</h2>
 <p>Frames are sampled at evenly-spaced timestamps across the GIF&#39;s full duration. If you ask for more frames than the GIF actually has, you get every frame (no duplication, no resampling).</p>
 <p><code>--cols 0</code> (the default) picks a column count that yields a roughly square grid; otherwise the layout is <code>cols × ceil(frames / cols)</code>.</p>
+<p>Output is limited to 40 million pixels. Dimensions or padding that overflow or exceed that budget return an error before allocating the sheet.</p>
 <h2 id="writing-to-stdout"><a class="anchor" href="#writing-to-stdout" aria-label="Anchor link">#</a>Writing to stdout</h2>
 <pre><code class="language-bash"><span class="hl-cmd">gifgrep</span> sheet <span class="hl-cmd">cat</span>.gif <span class="hl-f">--frames</span> <span class="hl-n">9</span> <span class="hl-f">--cols</span> <span class="hl-n">3</span> <span class="hl-f">-o</span> - &gt; sheet.png
 <span class="hl-cmd">gifgrep</span> sheet <span class="hl-cmd">cat</span>.gif <span class="hl-f">-o</span> - | pngquant - &gt; sheet-small.png</code></pre>

--- a/docs/sheet.md
+++ b/docs/sheet.md
@@ -36,6 +36,8 @@ Frames are sampled at evenly-spaced timestamps across the GIF's full duration. I
 
 `--cols 0` (the default) picks a column count that yields a roughly square grid; otherwise the layout is `cols × ceil(frames / cols)`.
 
+Output is limited to 40 million pixels. Dimensions or padding that overflow or exceed that budget return an error before allocating the sheet.
+
 ## Writing to stdout
 
 ```bash

--- a/docs/still.html
+++ b/docs/still.html
@@ -287,6 +287,7 @@ body:not(.home) .doc>h1:first-child{display:none}
 --reveal                   open the resulting file in your file manager
 -q / -v / --no-color       standard logging flags</code></pre>
 <p><code>--at</code> accepts seconds (<code>1.5</code>, <code>1.5s</code>) or milliseconds (<code>250ms</code>). If you ask for a timestamp past the GIF&#39;s total duration, the last available frame is used.</p>
+<p>Extraction uses the complete animation, including frames beyond the TUI&#39;s preview limit. Negative, non-finite, and overflowing timestamps are rejected.</p>
 <h2 id="how-frame-timing-works"><a class="anchor" href="#how-frame-timing-works" aria-label="Anchor link">#</a>How frame timing works</h2>
 <p>GIFs encode per-frame delays (in centiseconds). gifgrep accumulates these deltas to map your <code>--at</code> value onto the closest preceding frame. There&#39;s no resampling — you always get a frame that actually exists in the source.</p>
 <p>For a denser look at the GIF, see <a href="sheet.html"><code>sheet</code></a>.</p>

--- a/docs/still.md
+++ b/docs/still.md
@@ -38,6 +38,8 @@ gifgrep still cat.gif --at 0 -o cover.png --reveal
 
 `--at` accepts seconds (`1.5`, `1.5s`) or milliseconds (`250ms`). If you ask for a timestamp past the GIF's total duration, the last available frame is used.
 
+Extraction uses the complete animation, including frames beyond the TUI's preview limit. Negative, non-finite, and overflowing timestamps are rejected.
+
 ## How frame timing works
 
 GIFs encode per-frame delays (in centiseconds). gifgrep accumulates these deltas to map your `--at` value onto the closest preceding frame. There's no resampling — you always get a frame that actually exists in the source.

--- a/gifdecode/decode.go
+++ b/gifdecode/decode.go
@@ -10,6 +10,7 @@ import (
 	_ "image/jpeg" // allow image.Decode fallback for stills
 	"image/png"
 	"io"
+	"math"
 	"sync"
 	"time"
 )
@@ -44,6 +45,12 @@ func DecodeReader(r io.Reader, opts Options) (*Frames, error) {
 }
 
 func decodeBytes(data []byte, opts Options) (*Frames, error) {
+	// Check the header before the image decoder can allocate pixel buffers.
+	if cfg, format, err := image.DecodeConfig(bytes.NewReader(data)); err == nil && (!opts.StrictGIF || format == "gif") {
+		if exceedsPixels(cfg.Width, cfg.Height, opts.MaxPixels) {
+			return nil, ErrTooLarge
+		}
+	}
 	g, err := gif.DecodeAll(bytes.NewReader(data))
 	if err != nil {
 		if opts.StrictGIF {
@@ -182,7 +189,7 @@ func encodePNG(img image.Image) ([]byte, error) {
 }
 
 func readAllLimit(r io.Reader, maxBytes int64) ([]byte, error) {
-	if maxBytes <= 0 {
+	if maxBytes <= 0 || maxBytes == math.MaxInt64 {
 		return io.ReadAll(r)
 	}
 	lr := &io.LimitedReader{R: r, N: maxBytes + 1}
@@ -200,6 +207,5 @@ func exceedsPixels(width, height, maxPixels int) bool {
 	if maxPixels <= 0 {
 		return false
 	}
-	pixels := int64(width) * int64(height)
-	return pixels > int64(maxPixels)
+	return width > 0 && height > 0 && width > maxPixels/height
 }

--- a/gifdecode/limits_regression_test.go
+++ b/gifdecode/limits_regression_test.go
@@ -1,0 +1,24 @@
+package gifdecode
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestDecodeChecksDimensionsBeforeImageData(t *testing.T) {
+	// A complete GIF header/palette followed by no frames: dimensions already exceed the limit.
+	data := []byte{'G', 'I', 'F', '8', '9', 'a', 255, 255, 255, 255, 0x80, 0, 0, 0, 0, 0, 255, 255, 255}
+	if _, err := Decode(data, DefaultOptions()); !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("got %v, want dimension rejection before frame decoding", err)
+	}
+}
+
+func TestReadAllLimitMaxInt64(t *testing.T) {
+	want := []byte("GIF89a")
+	got, err := readAllLimit(bytes.NewReader(want), math.MaxInt64)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}

--- a/gifdecode/options.go
+++ b/gifdecode/options.go
@@ -15,6 +15,7 @@ const (
 )
 
 type Options struct {
+	// MaxFrames limits returned frames; zero uses the default, negative disables the limit.
 	MaxFrames    int
 	MaxPixels    int
 	MaxBytes     int64

--- a/internal/app/duration.go
+++ b/internal/app/duration.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding"
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -18,10 +19,16 @@ func (d *DurationValue) UnmarshalText(text []byte) error {
 		return errors.New("empty duration")
 	}
 	if parsed, err := time.ParseDuration(raw); err == nil {
+		if parsed < 0 {
+			return errors.New("negative duration")
+		}
 		*d = DurationValue(parsed)
 		return nil
 	}
 	if secs, err := strconv.ParseFloat(raw, 64); err == nil {
+		if math.IsNaN(secs) || math.IsInf(secs, 0) || secs >= float64(math.MaxInt64)/float64(time.Second) {
+			return errors.New("duration out of range")
+		}
 		if secs < 0 {
 			return errors.New("negative duration")
 		}

--- a/internal/app/extract.go
+++ b/internal/app/extract.go
@@ -40,7 +40,7 @@ func runExtract(opts model.Options) error {
 		return err
 	}
 	decodeOpts := gifdecode.DefaultOptions()
-	decodeOpts.MaxFrames = 0
+	decodeOpts.MaxFrames = -1
 	decoded, err := gifdecode.Decode(data, decodeOpts)
 	if err != nil {
 		return err

--- a/internal/app/extract_regression_test.go
+++ b/internal/app/extract_regression_test.go
@@ -1,0 +1,85 @@
+package app
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steipete/gifgrep/internal/model"
+)
+
+func TestExtractUsesCompleteAnimation(t *testing.T) {
+	palette := make(color.Palette, 61)
+	for i := range palette {
+		palette[i] = color.RGBA{R: uint8(i * 4), A: 255}
+	}
+	animation := &gif.GIF{Config: image.Config{Width: 2, Height: 2, ColorModel: palette}}
+	for i := range palette {
+		frame := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+		for j := range frame.Pix {
+			frame.Pix[j] = uint8(i)
+		}
+		animation.Image = append(animation.Image, frame)
+		animation.Delay = append(animation.Delay, 10)
+	}
+	var data bytes.Buffer
+	if err := gif.EncodeAll(&data, animation); err != nil {
+		t.Fatal(err)
+	}
+	input := filepath.Join(t.TempDir(), "long.gif")
+	if err := os.WriteFile(input, data.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, still := range []bool{true, false} {
+		output := filepath.Join(t.TempDir(), "output.png")
+		opts := model.Options{GifInput: input, OutPath: output, StillSet: still}
+		if still {
+			opts.StillAt = 10 * time.Second
+		} else {
+			opts.StillsCount = 61
+			opts.StillsCols = 61
+		}
+		if err := runExtract(opts); err != nil {
+			t.Fatal(err)
+		}
+		raw, err := os.ReadFile(output)
+		if err != nil {
+			t.Fatal(err)
+		}
+		img, err := png.Decode(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		x := 0
+		if !still {
+			x = 120
+			if img.Bounds().Dx() != 122 {
+				t.Fatalf("sheet omitted frames: %v", img.Bounds())
+			}
+		}
+		r, _, _, _ := img.At(x, 0).RGBA()
+		if r != 240*257 {
+			t.Fatalf("still=%v: final frame red=%d, want %d", still, r, 240*257)
+		}
+	}
+}
+
+func TestDurationRejectsInvalidNumbers(t *testing.T) {
+	for _, raw := range []string{"NaN", "Inf", "+Inf", "-Inf", "1e100", "9223372037", "-1", "-1s"} {
+		t.Run(raw, func(t *testing.T) {
+			d := DurationValue(time.Second)
+			if err := d.UnmarshalText([]byte(raw)); err == nil {
+				t.Fatalf("accepted %q as %v", raw, time.Duration(d))
+			}
+			if d != DurationValue(time.Second) {
+				t.Fatal("invalid input changed duration")
+			}
+		})
+	}
+}

--- a/internal/stills/bounds_test.go
+++ b/internal/stills/bounds_test.go
@@ -1,0 +1,33 @@
+package stills
+
+import (
+	"errors"
+	"image/color"
+	"math"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/steipete/gifgrep/gifdecode"
+)
+
+func TestContactSheetRejectsOversizedDimensions(t *testing.T) {
+	decoded := &gifdecode.Frames{Width: 2, Height: 2, Frames: []gifdecode.Frame{{PNG: makeSolidPNG(color.White, 2, 2)}, {PNG: makeSolidPNG(color.White, 2, 2)}}}
+	for _, opts := range []SheetOptions{
+		{Count: 1, Columns: math.MaxInt},
+		{Count: 2, Columns: 2, Padding: math.MaxInt},
+		{Count: 2, Columns: 1, Padding: math.MaxInt},
+		{Count: 1, Columns: 40_000_000},
+	} {
+		if _, err := ContactSheet(decoded, opts); !errors.Is(err, ErrInvalidSheet) {
+			t.Fatalf("%+v: got %v", opts, err)
+		}
+	}
+}
+
+func TestSampleEveryFrameWithUnevenDelays(t *testing.T) {
+	frames := []gifdecode.Frame{{Delay: time.Second}, {Delay: time.Millisecond}, {Delay: time.Millisecond}, {Delay: time.Millisecond}}
+	if got := sampleIndices(frames, len(frames)); !slices.Equal(got, []int{0, 1, 2, 3}) {
+		t.Fatalf("all-frame sampling duplicated frames: %v", got)
+	}
+}

--- a/internal/stills/stills.go
+++ b/internal/stills/stills.go
@@ -19,6 +19,8 @@ var (
 	ErrInvalidSheet = errors.New("invalid sheet size")
 )
 
+const maxSheetPixels = 40_000_000
+
 type SheetOptions struct {
 	Count      int
 	Columns    int
@@ -93,10 +95,15 @@ func ContactSheet(decoded *gifdecode.Frames, opts SheetOptions) ([]byte, error) 
 		return nil, ErrInvalidSheet
 	}
 
-	rows := int(math.Ceil(float64(opts.Count) / float64(opts.Columns)))
-
-	sheetWidth := frameWidth*opts.Columns + opts.Padding*(opts.Columns-1)
-	sheetHeight := frameHeight*rows + opts.Padding*(rows-1)
+	rows := 1 + (opts.Count-1)/opts.Columns
+	sheetWidth, ok := sheetDimension(frameWidth, opts.Columns, opts.Padding)
+	if !ok {
+		return nil, ErrInvalidSheet
+	}
+	sheetHeight, ok := sheetDimension(frameHeight, rows, opts.Padding)
+	if !ok || sheetWidth > maxSheetPixels/sheetHeight {
+		return nil, ErrInvalidSheet
+	}
 
 	sheet := image.NewRGBA(image.Rect(0, 0, sheetWidth, sheetHeight))
 	draw.Draw(sheet, sheet.Bounds(), &image.Uniform{C: opts.Background}, image.Point{}, draw.Src)
@@ -125,6 +132,20 @@ func ContactSheet(decoded *gifdecode.Frames, opts SheetOptions) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
+func sheetDimension(frame, cells, padding int) (int, bool) {
+	if frame > maxSheetPixels/cells {
+		return 0, false
+	}
+	size := frame * cells
+	if cells > 1 {
+		if padding > (maxSheetPixels-size)/(cells-1) {
+			return 0, false
+		}
+		size += padding * (cells - 1)
+	}
+	return size, true
+}
+
 func totalDuration(frames []gifdecode.Frame) time.Duration {
 	var total time.Duration
 	for _, frame := range frames {
@@ -139,6 +160,13 @@ func sampleIndices(frames []gifdecode.Frame, count int) []int {
 	}
 	if len(frames) == 0 {
 		return []int{}
+	}
+	if count >= len(frames) {
+		indices := make([]int, len(frames))
+		for i := range indices {
+			indices[i] = i
+		}
+		return indices
 	}
 	if count == 1 {
 		return []int{0}


### PR DESCRIPTION
`still`/`sheet` used zero to request unlimited decoding, but zero means the decoder's 60-frame default. Use the documented negative sentinel so extraction covers the complete GIF. When every frame is requested, sample each source frame once; time sampling previously duplicated long-delay frames and omitted short ones.

Validate image dimensions before decoding pixel buffers, and contact-sheet dimensions/area before multiplication and allocation (40-million-pixel output budget). Prevent MaxInt64 byte-limit overflow, and reject negative/non-finite/overflowing timestamps consistently. Document the extraction behavior and limits.

New regressions failed on the base and pass on the candidate: 61-frame extraction, uneven frame delays, oversized sheet dimensions, header-first image rejection, MaxInt64 byte reads and invalid durations. Full Go suite, lint (0 issues), gofumpt and generated-doc link checks passed. Isolated Codex review through P2: scoped-clean.

Live proof with the built CLI and a synthetic 61-frame GIF: `still --at 10s` previously returned red=236 (frame 60), now red=240 (frame 61). `sheet --frames 1 --cols 9223372036854775807` previously silently wrote a 6×2 transparent PNG; now exits 1 with `invalid sheet size`. `still --at NaN` previously succeeded; now exits 2 with `duration out of range`.
