### PR TITLE
fix(search): redact request secrets and propagate output errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Compatibility: source builds now require Go 1.26, the oldest maintained Go line, for the updated terminal/system dependencies; prebuilt binary usage is unchanged.
 - Dependencies: update x/term to 0.46.0, x/sys to 0.48.0, and Playwright to 1.63.0; test Linux/macOS, the minimum Go line, race detection, built CLI commands, and generated docs in CI.
+- Search: keep API keys and queries out of transport errors, and return failure when buffered stdout cannot be written.
 - Docs: correct search formats, thumbnail flags, optional JSON fields, and terminal preview behavior; keep the generated site in sync.
 
 ## 0.4.1 - 2026-09-11

--- a/internal/app/output_error_test.go
+++ b/internal/app/output_error_test.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/steipete/gifgrep/internal/model"
+	"github.com/steipete/gifgrep/internal/testutil"
+)
+
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestSearchReportsOutputFailure(t *testing.T) {
+	t.Setenv("GIPHY_API_KEY", "synthetic")
+	failure := errors.New("output unavailable")
+	testutil.WithTransport(t, &testutil.FakeTransport{}, func() {
+		for _, format := range []string{"json", "url", "plain", "md", "tsv", "comment"} {
+			err := runSearch(errorWriter{failure}, io.Discard, model.Options{Source: "giphy", Format: format}, "cats")
+			if !errors.Is(err, failure) {
+				t.Errorf("%s: got %v, want output failure", format, err)
+			}
+		}
+	})
+}

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -34,19 +34,19 @@ func runSearch(stdout io.Writer, stderr io.Writer, opts model.Options, query str
 
 	format := resolveOutputFormat(opts, stdout)
 	out := bufio.NewWriter(stdout)
-	defer func() { _ = out.Flush() }()
 	if format == formatJSON {
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
-		return enc.Encode(results)
+		if err := enc.Encode(results); err != nil {
+			return err
+		}
+	} else {
+		useColor := shouldUseColor(opts, stdout)
+		thumbs := thumbsProtocol(opts, stdout, format)
+		termCols := termColumns(stdout, thumbs)
+		writeSearchResults(out, opts, useColor, thumbs, results, termCols, format)
 	}
-
-	useColor := shouldUseColor(opts, stdout)
-	thumbs := thumbsProtocol(opts, stdout, format)
-	termCols := termColumns(stdout, thumbs)
-
-	writeSearchResults(out, opts, useColor, thumbs, results, termCols, format)
-	return nil
+	return out.Flush()
 }
 
 func logSearchConfig(stderr io.Writer, opts model.Options) {

--- a/internal/search/error_test.go
+++ b/internal/search/error_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gifgrep/internal/model"
+	"github.com/steipete/gifgrep/internal/testutil"
+)
+
+type failingTransport struct{ err error }
+
+func (t failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestTransportErrorDoesNotExposeSearchCredentials(t *testing.T) {
+	const key = "synthetic-secret-value"
+	t.Setenv("GIPHY_API_KEY", key)
+	t.Setenv("KLIPY_API_KEY", key)
+	failure := errors.New("connection refused")
+	testutil.WithTransport(t, failingTransport{failure}, func() {
+		for _, source := range []string{"giphy", "klipy", "auto"} {
+			_, err := Search("private-query", model.Options{Source: source})
+			if !errors.Is(err, failure) {
+				t.Fatalf("%s: lost transport cause: %v", source, err)
+			}
+			if strings.Contains(err.Error(), key) || strings.Contains(err.Error(), "private-query") {
+				t.Errorf("%s: error exposes query parameters", source)
+			}
+		}
+	})
+}

--- a/internal/search/http.go
+++ b/internal/search/http.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -17,6 +18,11 @@ func fetchSearchJSON(endpoint string, params url.Values, dest any) error {
 	req.Header.Set("User-Agent", "gifgrep")
 	resp, err := client.Do(req)
 	if err != nil {
+		var requestErr *url.Error
+		if errors.As(err, &requestErr) {
+			// Provider URLs carry API keys and queries; retain only the public endpoint.
+			return &url.Error{Op: requestErr.Op, URL: endpoint, Err: requestErr.Err}
+		}
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()


### PR DESCRIPTION
Search transport errors printed the full provider URL, including API keys and query text. Retain only the public endpoint in the returned URL error while preserving the underlying cause for errors.Is/errors.As and provider fallback.

Search also returned success before checking its buffered stdout flush. Flush before returning for JSON and all text formats so failed writes produce a nonzero exit.

New regressions failed on the base for all six output formats and GIPHY/KLIPY/auto errors, then passed after the fixes. Full Go suite, lint (0 issues), gofumpt and isolated Codex review through P2 passed (scoped-clean).

Live proof: a compiled CLI with only its HTTP transport redirected to a loopback fixture previously exited 0 for both JSON and URL output sent to a read-only descriptor; it now exits 1 with `bad file descriptor`. A refused provider connection previously printed a synthetic key and query in stderr; it now prints only `https://api.giphy.com/v1/gifs/search` and the connection error. No real credentials were used.
